### PR TITLE
Fix the wiring connections with missing endpoints

### DIFF
--- a/src/wirecloud/defaulttheme/static/css/wiring/_defaults.scss
+++ b/src/wirecloud/defaulttheme/static/css/wiring/_defaults.scss
@@ -109,6 +109,15 @@ $connection-background-options-border-color: transparentize(lighten($connection-
 
 $connection-background-text-color: rgba(0, 0, 0, 0.2) !default;
 
+$connection-missing-bg:           transparentize($state-danger-bg, 0.1) !default;
+$connection-missing-border-color: transparentize($state-danger-border, 0.1) !default;
+
+$connection-missing-options-bg:           transparentize($state-danger-bg, 0.1) !default;
+$connection-missing-options-border-color: transparentize($state-danger-border, 0.1) !default;
+
+$connection-missing-text-color: lighten($state-danger-text, 5%) !default;
+$connection-missing-text-hover-color: $state-danger-text !default;
+
 $connection-active-bg:           rgb(180, 230, 250) !default;
 $connection-active-border-color: darken($component-active-bg, 20%) !default;
 

--- a/src/wirecloud/defaulttheme/static/css/wiring/wiring_components.scss
+++ b/src/wirecloud/defaulttheme/static/css/wiring/wiring_components.scss
@@ -226,6 +226,10 @@
         width: 100%;
         padding: 0;
         background-color: $component-body-bg;
+
+        &:empty {
+            display: none;
+        }
     }
 
     &.dragging {
@@ -304,6 +308,10 @@
             right,
             $target-endpoint-anchor-bg
         );
+    }
+
+    &:empty {
+        display: none;
     }
 
     .endpoint:hover,

--- a/src/wirecloud/defaulttheme/static/css/wiring/wiring_connections.scss
+++ b/src/wirecloud/defaulttheme/static/css/wiring/wiring_connections.scss
@@ -36,6 +36,12 @@
         .btn-svg-plain {
             cursor: pointer;
             fill: $connection-text-color;
+
+            &:hover,
+            &.active {
+                fill: $connection-active-text-hover-color;
+                text-shadow: $connection-text-hover-shadow;
+            }
         }
     }
 }
@@ -68,11 +74,44 @@
 }
 
 // ============================================================================
+// WIRING VIEW - CONNECTION - MISSING
+// ============================================================================
+
+.connection.missing {
+
+    .connection-body {
+        stroke: $connection-missing-bg;
+    }
+
+    .connection-border {
+        stroke: $connection-missing-border-color;
+    }
+
+    .connection-options {
+
+        .btn-svg-group {
+            fill: $connection-missing-options-bg;
+            stroke: $connection-missing-options-border-color;
+        }
+
+        .btn-svg-plain {
+            fill: $connection-missing-text-color;
+
+            &:hover,
+            &.active {
+                fill: $connection-missing-text-hover-color;
+            }
+        }
+    }
+}
+
+// ============================================================================
 // WIRING VIEW - CONNECTION - ACTIVE
 // ============================================================================
 
 .connection.active,
 .connection.editable,
+.connection.missing.active,
 .connection.background.active {
 
     .connection-body {
@@ -93,6 +132,12 @@
         .btn-svg-plain {
             fill: $connection-active-text-color;
             text-shadow: $connection-active-text-shadow;
+
+            &:hover,
+            &.active {
+                fill: $connection-active-text-hover-color;
+                text-shadow: $connection-text-hover-shadow;
+            }
         }
     }
 }
@@ -105,15 +150,6 @@
 
     .connection-border {
         stroke-dasharray: $connection-editable-border-dasharray;
-    }
-}
-
-.connection .connection-options .btn-svg-plain {
-
-    &:hover,
-    &.active {
-        fill: $connection-active-text-hover-color;
-        text-shadow: $connection-text-hover-shadow;
     }
 }
 

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js
@@ -152,10 +152,6 @@
                 this.addClassName("missing");
             }
 
-            if (!this.hasEndpoints()) {
-                this.body.remove();
-            }
-
             if (options.collapsed) {
                 this.collapsed = true;
             }
@@ -550,8 +546,7 @@
 
         this.body
             .removeChild(this.endpoints.target)
-            .removeChild(this.endpoints.source)
-            .remove();
+            .removeChild(this.endpoints.source);
 
         this.heading
             .appendChild(this.endpoints.target)
@@ -584,8 +579,7 @@
 
         this.body
             .appendChild(this.endpoints.target)
-            .appendChild(this.endpoints.source)
-            .appendTo(this);
+            .appendChild(this.endpoints.source);
 
         offsetWidth = this.get().offsetWidth - collapsedWidth;
 

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/Connection.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/Connection.js
@@ -111,6 +111,12 @@
                     set: function set(value) {this._oneditable(value);}
                 },
 
+                missing: {
+                    get: function get() {
+                        return this.created && (this.source.endpoint.missing || this.target.endpoint.missing);
+                    }
+                },
+
                 removeAllowed: {
                     get: function get() {return removeAllowed;},
                     set: function set(value) {
@@ -358,6 +364,8 @@
                 if (!this.created) {
                     return this;
                 }
+
+                this.toggleClassName('missing', this.missing);
 
                 sourcePosition = this.source.endpoint.anchorPosition;
                 targetPosition = this.target.endpoint.anchorPosition;

--- a/src/wirecloud/platform/wiring/tests.py
+++ b/src/wirecloud/platform/wiring/tests.py
@@ -1217,6 +1217,21 @@ class EndpointMissingTestCase(WirecloudSeleniumTestCase):
 
         self.check_input_endpoint_exceptions()
 
+    def test_missing_input_and_output_endpoints(self):
+        # Update wiring connections to set (1) a connection bound to missing
+        # input-endpoint and (2) a connection bound to missing output-endpoint.
+        # From wiring editor, those connections must be displayed.
+
+        workspace = Workspace.objects.get(id=2)
+        workspace.wiringStatus['connections'][0]['target']['endpoint'] = 'missing'
+        workspace.wiringStatus['connections'][1]['source']['endpoint'] = 'missing'
+        workspace.save()
+
+        self.login(username='user_with_workspaces')
+
+        with self.wiring_view as wiring:
+            self.assertEqual(len(wiring.filter_connections_by_properties('missing')), 2)
+
 
 @wirecloud_selenium_test_case
 class EndpointSortingTestCase(WirecloudSeleniumTestCase):

--- a/src/wirecloud/platform/wiring/tests.py
+++ b/src/wirecloud/platform/wiring/tests.py
@@ -1015,18 +1015,18 @@ class ConnectionReadOnlyTestCase(WirecloudSeleniumTestCase):
 
 
 @wirecloud_selenium_test_case
-class EndpointBasicRecommendationTestCase(WirecloudSeleniumTestCase):
+class EndpointManagementTestCase(WirecloudSeleniumTestCase):
 
     fixtures = ('initial_data', 'selenium_test_data', 'user_with_workspaces')
     tags = ('wirecloud-selenium', 'wirecloud-wiring', 'wirecloud-wiring-selenium')
 
     @classmethod
     def setUpClass(cls):
-        super(EndpointBasicRecommendationTestCase, cls).setUpClass()
+        super(EndpointManagementTestCase, cls).setUpClass()
 
         if not selenium_supports_draganddrop(cls.driver):  # pragma: no cover
             cls.tearDownClass()
-            raise unittest.SkipTest('EndpointBasicRecommendationTestCase needs to use native events supported on Selenium <= 2.37.2 when using FirefoxDriver (not available on Mac OS)')
+            raise unittest.SkipTest('EndpointManagementTestCase needs to use native events support on selenium <= 2.37.2 when using FirefoxDriver (not available on Mac OS)')
 
     def test_endpoint_are_highlighted_when_the_mouse_is_over(self):
         self.login(username='user_with_workspaces', next='/user_with_workspaces/WiringTests')
@@ -1077,21 +1077,6 @@ class EndpointBasicRecommendationTestCase(WirecloudSeleniumTestCase):
             self.assertTrue(source2.active)
             self.assertTrue(source3.active)
             target1.drop_connection()
-
-
-@wirecloud_selenium_test_case
-class EndpointCollapsedTestCase(WirecloudSeleniumTestCase):
-
-    fixtures = ('initial_data', 'selenium_test_data', 'user_with_workspaces')
-    tags = ('wirecloud-selenium', 'wirecloud-wiring', 'wirecloud-wiring-selenium')
-
-    @classmethod
-    def setUpClass(cls):
-        super(EndpointCollapsedTestCase, cls).setUpClass()
-
-        if not selenium_supports_draganddrop(cls.driver):  # pragma: no cover
-            cls.tearDownClass()
-            raise unittest.SkipTest('EndpointCollapsedTestCase needs to use native events support on selenium <= 2.37.2 when using FirefoxDriver (not available on Mac OS)')
 
     def test_component_endpoints_can_be_collapsed_and_expanded(self):
         self.login(username='user_with_workspaces')
@@ -1145,13 +1130,6 @@ class EndpointCollapsedTestCase(WirecloudSeleniumTestCase):
 
             menu_dropdown = operator.display_preferences()
             self.assertTrue('disabled' in menu_dropdown.get_entry('Order endpoints').get_attribute('class').split())
-
-
-@wirecloud_selenium_test_case
-class EndpointMissingTestCase(WirecloudSeleniumTestCase):
-
-    fixtures = ('initial_data', 'selenium_test_data', 'user_with_workspaces')
-    tags = ('wirecloud-selenium', 'wirecloud-wiring', 'wirecloud-wiring-selenium')
 
     def check_input_endpoint_exceptions(self):
 
@@ -1232,21 +1210,6 @@ class EndpointMissingTestCase(WirecloudSeleniumTestCase):
         with self.wiring_view as wiring:
             self.assertEqual(len(wiring.filter_connections_by_properties('missing')), 2)
 
-
-@wirecloud_selenium_test_case
-class EndpointSortingTestCase(WirecloudSeleniumTestCase):
-
-    fixtures = ('initial_data', 'selenium_test_data', 'user_with_workspaces')
-    tags = ('wirecloud-selenium', 'wirecloud-wiring', 'wirecloud-wiring-selenium')
-
-    @classmethod
-    def setUpClass(cls):
-        super(EndpointSortingTestCase, cls).setUpClass()
-
-        if not selenium_supports_draganddrop(cls.driver):  # pragma: no cover
-            cls.tearDownClass()
-            raise unittest.SkipTest('EndpointSortingTestCase needs to use native events support on selenium <= 2.37.2 when using FirefoxDriver (not available on Mac OS)')
-
     @uses_extra_resources(('Wirecloud_TestOperatorMultiendpoint_1.0.wgt',), shared=True)
     def test_endpoint_sorting_in_operators(self):
         self.login()
@@ -1272,21 +1235,6 @@ class EndpointSortingTestCase(WirecloudSeleniumTestCase):
             with widget.sort_endpoints as component_editable:
                 component_editable.move_endpoint('source', "output1", "output2")
                 component_editable.move_endpoint('target', "input1", "input3")
-
-
-@wirecloud_selenium_test_case
-class EndpointStickyEffectTestCase(WirecloudSeleniumTestCase):
-
-    fixtures = ('initial_data', 'selenium_test_data', 'user_with_workspaces')
-    tags = ('wirecloud-selenium', 'wirecloud-wiring', 'wirecloud-wiring-selenium',)
-
-    @classmethod
-    def setUpClass(cls):
-        super(EndpointStickyEffectTestCase, cls).setUpClass()
-
-        if not selenium_supports_draganddrop(cls.driver):  # pragma: no cover
-            cls.tearDownClass()
-            raise unittest.SkipTest('EndpointStickyEffectTestCase needs to use native events support on selenium <= 2.37.2 when using FirefoxDriver (not available on Mac OS)')
 
     def test_sticky_effect_in_target_endpoint_label(self):
         self.login()


### PR DESCRIPTION
This pull request resolves #75 and the bug was that the components with no endpoints, within wiring editor, did not add a container (HTML Element bound to DOM) for possible missing endpoints loaded during the wiring editor data recovery.