### PR TITLE
Wiring Editor: Use shortcuts to remove components selected

### DIFF
--- a/src/wirecloud/commons/static/js/StyledElements/Utils.js
+++ b/src/wirecloud/commons/static/js/StyledElements/Utils.js
@@ -920,6 +920,7 @@ if (window.StyledElements == null) {
     // ==================================================================================
 
     var keyCodeMap = {
+        8: 'Backspace',
         9: 'Tab',
         13: 'Enter',
         27: 'Escape',
@@ -927,7 +928,8 @@ if (window.StyledElements == null) {
         37: 'ArrowLeft',
         38: 'ArrowUp',
         39: 'ArrowRight',
-        40: 'ArrowDown'
+        40: 'ArrowDown',
+        46: 'Delete'
     };
 
     var keyFixes = {

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
@@ -63,6 +63,8 @@ Wirecloud.ui = Wirecloud.ui || {};
 
             this.sortableComponent = null;
             this.autoOperatorId = 1;
+
+            this._document_onkeydown_bound = document_onkeydown.bind(this);
         },
 
         inherit: se.Alternative,
@@ -415,6 +417,8 @@ Wirecloud.ui = Wirecloud.ui || {};
         this.workspace.wiring.load(this.toJSON()).save();
         readyView.call(this);
 
+        document.removeEventListener('keydown', this._document_onkeydown_bound);
+
         return this;
     };
 
@@ -443,6 +447,8 @@ Wirecloud.ui = Wirecloud.ui || {};
 
         readyView.call(this);
         loadWiringStatus.call(this);
+
+        document.addEventListener('keydown', this._document_onkeydown_bound);
 
         return this;
     };
@@ -649,6 +655,53 @@ Wirecloud.ui = Wirecloud.ui || {};
             id: parseInt(kwargs[1]),
             endpoint: kwargs[2]
         });
+    };
+
+    var clearComponentSelection = function clearComponentSelection() {
+        var type, id;
+
+        for (type in this.selectedComponents) {
+            for (id in this.selectedComponents[type]) {
+                this.selectedComponents[type][id].active = false;
+                delete this.selectedComponents[type][id].initialPosition;
+                delete this.selectedComponents[type][id];
+            }
+        }
+
+        this.selectedCount = 0;
+    };
+
+    var document_onkeydown = function document_onkeydown(event) {
+        var type, id, component, componentsToRemove = [];
+
+        switch (utils.normalizeKey(event)) {
+        case 'Backspace':
+        case 'Delete':
+
+            if (hasSelectedComponents.call(this)) {
+
+                for (type in this.selectedComponents) {
+                    for (id in this.selectedComponents[type]) {
+                        component = this.selectedComponents[type][id];
+
+                        if (component.isRemovable()) {
+                            componentsToRemove.push(component);
+                        }
+                    }
+                }
+
+                if (componentsToRemove.length) {
+                    this.behaviourEngine.removeComponentList(componentsToRemove);
+                    clearComponentSelection.call(this);
+                    event.preventDefault();
+                }
+            }
+            break;
+        }
+    };
+
+    var hasSelectedComponents = function hasSelectedComponents() {
+        return Object.keys(this.selectedComponents.operator).length > 0 || Object.keys(this.selectedComponents.widget).length > 0;
     };
 
     var behaviourengine_onenable = function behaviourengine_onenable(behaviourEngine, enabled) {

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js
@@ -356,6 +356,10 @@
                 return this.endpoints.source.canSort() || this.endpoints.target.canSort();
             },
 
+            isRemovable = function isRemovable() {
+                return !this.readonly && !this.background;
+            },
+
             /**
              * @override
              */

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ComponentDraggablePrefs.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ComponentDraggablePrefs.js
@@ -114,7 +114,7 @@
     };
 
     var canDeleteCascade = function canDeleteCascade() {
-        return !this.readonly && !this.background;
+        return this.isRemovable();
     };
 
     var canSortEndpoints = function canSortEndpoints() {

--- a/src/wirecloud/platform/wiring/tests.py
+++ b/src/wirecloud/platform/wiring/tests.py
@@ -776,6 +776,20 @@ class ComponentDraggableTestCase(WirecloudSeleniumTestCase):
             component1.remove()
             self.assertEqual(len(wiring.find_connections()), 1)
 
+    def test_remove_components_using_key_delete_when_behaviour_engine_enabled(self):
+        pass
+
+    def test_remove_components_using_key_delete_when_behaviour_engine_disabled(self):
+        # From wiring editor, select (1) one component belonging only to the
+        # current behaviour, (2) one component belonging to the current behaviour
+        # and another behaviour, and (3) one component belonging to another
+        # behaviour. Then, press the key 'Delete' to remove such components.
+        #
+        # In the case (1), the platform should ask to the user.
+        # In the case (2), the platform should remove the component selected.
+        # In the case (3), the platform should ignore the component selected.
+        pass
+
 
 @wirecloud_selenium_test_case
 class ComponentMissingTestCase(WirecloudSeleniumTestCase):


### PR DESCRIPTION
This pull-request resolves #77 and for this, from wiring editor you can select one or more components and then, remove them using keyboard shortcuts (del or backspace).