### PR TITLE
Wiring Editor: connections are not redrawn after ordering the endpoints

### DIFF
--- a/src/wirecloud/commons/utils/remote.py
+++ b/src/wirecloud/commons/utils/remote.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2008-2015 CoNWeT Lab., Universidad Politécnica de Madrid
+# Copyright (c) 2008-2016 CoNWeT Lab., Universidad Politécnica de Madrid
 
 # This file is part of Wirecloud.
 
@@ -832,6 +832,7 @@ class WiringConnectionTester(object):
     def __init__(self, testcase, element):
         self.testcase = testcase
         self.element = element
+        self.distance = element.find_element_by_css_selector('.connection-body').get_attribute('d')
 
     @property
     def background(self):
@@ -867,6 +868,11 @@ class WiringConnectionTester(object):
 
     def _get_btn_by_class(self, class_name):
         return ButtonTester(self.testcase, self.element.find_element_by_css_selector(".connection-options .{}".format(class_name)))
+
+    def has_changed(self):
+        old_distance = self.distance
+        self.distance = self.element.find_element_by_css_selector('.connection-body').get_attribute('d')
+        return old_distance != self.distance
 
     def display_preferences(self):
         button = self.btn_prefs
@@ -1867,10 +1873,12 @@ class WiringComponentSidebarTester(BaseWiringViewTester):
         # Wait until the component is added to the diagram
         WebDriverWait(self.testcase.driver, 5).until(lambda driver: old_components + 1 == len(self.section_diagram.find_elements_by_css_selector(".component-%s[data-id]" % component_type)))
         new_component = self._find_component_by_title(component_type, component_title)
+        WebDriverWait(self.testcase.driver, 5).until(WEC.element_be_still(self.panel))
 
         return new_component
 
     def create_operator(self, group_title):
+        self.display_component_group('operator')
 
         group = self.find_component_group_by_title('operator', group_title)
         group.createComponent()
@@ -1879,6 +1887,7 @@ class WiringComponentSidebarTester(BaseWiringViewTester):
 
     def display_component_group(self, component_type):
         button = getattr(self, "btn_show_%s_group" % component_type)
+        WebDriverWait(self.testcase.driver, 5).until(WEC.element_be_still(self.panel))
 
         if not button.active:
             WebDriverWait(self.testcase.driver, 5).until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".wiring-sidebar .panel-components .btn-list-%s-group" % component_type)))

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/EndpointGroup.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/EndpointGroup.js
@@ -1,5 +1,5 @@
 /*
- *     Copyright (c) 2015 CoNWeT Lab., Universidad Politécnica de Madrid
+ *     Copyright (c) 2015-2016 CoNWeT Lab., Universidad Politécnica de Madrid
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -125,7 +125,7 @@
              *      The instance on which the member is called.
              */
             refresh: function refresh() {
-                var currentOrder;
+                var currentOrder, name;
 
                 if (!this.canSort()) {
                     return this;
@@ -136,6 +136,10 @@
                 });
 
                 this.modified = !equalsLists(this.originalOrder, currentOrder);
+
+                for (name in this.endpoints) {
+                    this.endpoints[name].refresh();
+                }
 
                 return this;
             },

--- a/src/wirecloud/platform/wiring/tests.py
+++ b/src/wirecloud/platform/wiring/tests.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015 CoNWeT Lab., Universidad Politécnica de Madrid
+# Copyright (c) 2011-2016 CoNWeT Lab., Universidad Politécnica de Madrid
 
 # This file is part of Wirecloud.
 
@@ -1341,10 +1341,20 @@ class EndpointManagementTestCase(WirecloudSeleniumTestCase):
 
         with self.wiring_view as wiring:
             with wiring.component_sidebar as sidebar:
-                widget = sidebar.add_component('widget', "Test_Multiendpoint")
+                widget = sidebar.add_component('widget', "Test_Multiendpoint", x=100)
+                source = widget.find_endpoint_by_title('source', "output1")
+
+                sidebar.create_operator("TestOperator")
+                operator = sidebar.add_component('operator', "TestOperator", x=400)
+                target = operator.find_endpoint_by_title('target', 'input')
+
+                source.connect(target)
+
+            connection = wiring.find_connections()[0]
 
             with widget.sort_endpoints as component_editable:
                 component_editable.move_endpoint('source', "output1", "output2")
+                self.assertTrue(connection.has_changed())
                 component_editable.move_endpoint('target', "input1", "input3")
 
     def test_sticky_effect_in_target_endpoint_label(self):


### PR DESCRIPTION
This pull-request fixes #101 When you are ordering endpoints and you drag an endpoint, their connections are also updated.