### PR TITLE
Wiring Editor: re-connect the connection endpoints

### DIFF
--- a/src/wirecloud/commons/fixtures/user_with_workspaces.json
+++ b/src/wirecloud/commons/fixtures/user_with_workspaces.json
@@ -126,6 +126,34 @@
         }
     },
     {
+        "pk": 10,
+        "model": "platform.iwidget",
+        "fields": {
+            "widget": 1,
+            "layout": 0,
+            "name": "Test 1",
+            "tab": 106,
+            "refused_version": null,
+            "readOnly": false,
+            "positions": "{\"widget\":{\"minimized\":false,\"height\":24,\"width\":6,\"zIndex\":0,\"left\":0,\"top\":0,\"fulldragboard\":false},\"icon\":{\"top\":0,\"left\":0}}",
+            "variables": "{\"list\": \"default\", \"text\": \"initial text\", \"boolean\": false, \"password\": \"default\", \"number\": 2}"
+        }
+    },
+    {
+        "pk": 11,
+        "model": "platform.iwidget",
+        "fields": {
+            "widget": 1,
+            "layout": 0,
+            "name": "Test 2",
+            "tab": 106,
+            "refused_version": null,
+            "readOnly": false,
+            "positions": "{\"widget\":{\"minimized\":false,\"height\":24,\"width\":6,\"zIndex\":1,\"left\":6,\"top\":0,\"fulldragboard\":false},\"icon\":{\"top\":0,\"left\":0}}",
+            "variables": "{\"list\": \"default\", \"text\": \"initial text\", \"boolean\": false, \"password\": \"default\", \"number\": 2}"
+        }
+    },
+    {
         "pk": 101,
         "model": "platform.tab",
         "fields": {
@@ -176,6 +204,16 @@
         }
     },
     {
+        "pk": 106,
+        "model": "platform.tab",
+        "fields": {
+            "visible": true,
+            "name": "Tab",
+            "workspace": 6,
+            "position": 0
+        }
+    },
+    {
         "pk": 2,
         "model": "platform.workspace",
         "fields": {
@@ -216,6 +254,17 @@
             "forcedValues": "",
             "wiringStatus": "{\"connections\": [], \"operators\": {}, \"version\": \"2.0\", \"visualdescription\": {\"connections\": [], \"behaviours\": [], \"components\": {\"operator\": {}, \"widget\": {}}}}",
             "name": "WiringTests",
+            "groups": [],
+            "creator": 4
+        }
+    },
+    {
+        "pk": 6,
+        "model": "platform.workspace",
+        "fields": {
+            "forcedValues": "",
+            "wiringStatus": "{\"connections\": [{\"source\": {\"type\": \"widget\", \"id\": 10, \"endpoint\": \"outputendpoint\"}, \"readonly\": false, \"target\": {\"type\": \"widget\", \"id\": 11, \"endpoint\": \"inputendpoint\"}}, {\"source\": {\"type\": \"widget\", \"id\": 11, \"endpoint\": \"outputendpoint\"}, \"readonly\": false, \"target\": {\"type\": \"operator\", \"id\": 0, \"endpoint\": \"input\"}}, {\"source\": {\"type\": \"operator\", \"id\": 0, \"endpoint\": \"output\"}, \"readonly\": false, \"target\": {\"type\": \"widget\", \"id\": 10, \"endpoint\": \"inputendpoint\"}}], \"operators\": {\"0\": {\"preferences\": {}, \"name\": \"Wirecloud/TestOperator/1.0\", \"id\": \"0\"}}, \"version\": \"2.0\", \"visualdescription\": {\"connections\": [{\"sourcename\": \"widget/10/outputendpoint\", \"targethandle\": \"auto\", \"targetname\": \"widget/11/inputendpoint\", \"sourcehandle\": \"auto\"}, {\"sourcename\": \"widget/11/outputendpoint\", \"targethandle\": \"auto\", \"targetname\": \"operator/0/input\", \"sourcehandle\": \"auto\"}, {\"sourcename\": \"operator/0/output\", \"targethandle\": \"auto\", \"targetname\": \"widget/10/inputendpoint\", \"sourcehandle\": \"auto\"}], \"behaviours\": [{\"title\": \"Test 1\", \"components\": {\"operator\": {\"0\": {}}, \"widget\": {\"11\": {}}}, \"connections\": [{\"sourcename\": \"widget/11/outputendpoint\", \"targetname\": \"operator/0/input\"}]}, {\"title\": \"Test 2\", \"components\": {\"operator\": {\"0\": {}}, \"widget\": {\"10\": {}, \"11\": {}}}, \"connections\": [{\"sourcename\": \"widget/11/outputendpoint\", \"targetname\": \"operator/0/input\"}, {\"sourcename\": \"operator/0/output\", \"targetname\": \"widget/10/inputendpoint\"}, {\"sourcename\": \"widget/10/outputendpoint\", \"targetname\": \"widget/11/inputendpoint\"}]}], \"components\": {\"operator\": {\"0\": {\"position\": {\"y\": 20, \"x\": 440}, \"collapsed\": false, \"endpoints\": {\"source\": [\"output\"], \"target\": [\"input\"]}}}, \"widget\": {\"10\": {\"position\": {\"y\": 280, \"x\": 260}, \"name\": \"Wirecloud/Test/1.0\", \"endpoints\": {\"source\": [\"outputendpoint\"], \"target\": [\"inputendpoint\"]}}, \"11\": {\"position\": {\"y\": 10, \"x\": 60}, \"name\": \"Wirecloud/Test/1.0\", \"endpoints\": {\"source\": [\"outputendpoint\"], \"target\": [\"inputendpoint\"]}}}}}}",
+            "name": "WorkspaceBehaviours",
             "groups": [],
             "creator": 4
         }
@@ -262,6 +311,17 @@
             "manager": "",
             "user": 4,
             "workspace": 5
+        }
+    },
+    {
+        "pk": 6,
+        "model": "platform.userworkspace",
+        "fields": {
+            "active": false,
+            "reason_ref": "",
+            "manager": "",
+            "user": 4,
+            "workspace": 6
         }
     }
 ]

--- a/src/wirecloud/defaulttheme/static/css/wiring/_defaults.scss
+++ b/src/wirecloud/defaulttheme/static/css/wiring/_defaults.scss
@@ -128,6 +128,12 @@ $connection-active-text-color:       rgb(050, 150, 200) !default;
 $connection-active-text-shadow:      0 1px 0 rgb(255, 255, 255) !default;
 $connection-active-text-hover-color: darken($connection-active-text-color, 10%) !default;
 
+$connection-temporal-border-color: rgba(185, 205, 220, 0.9) !default;
+$connection-temporal-bg:           lighten($connection-temporal-border-color, 10%) !default;
+
+$connection-temporal-text-color:  rgb(185, 205, 220) !default;
+$connection-temporal-text-shadow: 0 1px 0 rgb(255, 255, 255) !default;
+
 $connection-editable-border-dasharray: 6, 2 !default;
 
 $connection-handle-width: 2px !default;

--- a/src/wirecloud/defaulttheme/static/css/wiring/wiring_components.scss
+++ b/src/wirecloud/defaulttheme/static/css/wiring/wiring_components.scss
@@ -315,8 +315,10 @@
     }
 
     .endpoint:hover,
-    .endpoint.active {
+    .endpoint.active,
+    .endpoint.active.disabled {
         background-color: $endpoint-active-bg;
+        opacity: 1;
 
         .endpoint-title {
             color: $endpoint-active-text-color;

--- a/src/wirecloud/defaulttheme/static/css/wiring/wiring_connections.scss
+++ b/src/wirecloud/defaulttheme/static/css/wiring/wiring_connections.scss
@@ -143,6 +143,35 @@
 }
 
 // ============================================================================
+// WIRING VIEW - CONNECTION - TEMPORAL
+// ============================================================================
+
+.connection.temporal,
+.connection.background.temporal {
+
+    .connection-body {
+        stroke: $connection-temporal-bg;
+    }
+
+    .connection-border {
+        stroke: $connection-temporal-border-color;
+    }
+
+    .connection-options {
+
+        .btn-svg-group {
+            fill: $connection-temporal-bg;
+            stroke: $connection-temporal-border-color;
+        }
+
+        .btn-svg-plain {
+            fill: $connection-temporal-text-color;
+            text-shadow: $connection-temporal-text-shadow;
+        }
+    }
+}
+
+// ============================================================================
 // WIRING VIEW - CONNECTION - EDITABLE
 // ============================================================================
 

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
@@ -1,7 +1,7 @@
 /*
  *     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER
  *
- *     Copyright (c) 2012-2015 Universidad Politécnica de Madrid
+ *     Copyright (c) 2012-2016 Universidad Politécnica de Madrid
  *     Copyright (c) 2012-2014 the Center for Open Middleware
  *
  *     Licensed under the Apache License, Version 2.0 (the
@@ -746,7 +746,7 @@ Wirecloud.ui = Wirecloud.ui || {};
         }
     };
 
-    var connection_onestablish = function connection_onestablish(connectionEngine, connection) {
+    var connection_onestablish = function connection_onestablish(connectionEngine, connection, connectionBackup) {
         /*jshint validthis:true */
 
         this.behaviourEngine.updateConnection(connection, connection.toJSON());
@@ -761,6 +761,29 @@ Wirecloud.ui = Wirecloud.ui || {};
             .on('optshare', function () {
                 this.behaviourEngine.updateConnection(connection, connection.toJSON(), true);
             }.bind(this));
+
+        if (connectionBackup != null) {
+            this.behaviourEngine.removeConnection(connectionBackup);
+
+            if (this.behaviourEngine.hasConnection(connectionBackup)) {
+                showConnectionChangeModal.call(this, connectionBackup);
+            }
+        }
+    };
+
+    var showConnectionChangeModal = function showConnectionChangeModal(connection) {
+        /*jshint validthis:true */
+        var modal, message;
+        var builder = new se.GUIBuilder();
+
+        message = builder.parse(builder.DEFAULT_OPENING + utils.gettext("The connection will also be modified for the rest of behaviours, would you like to continue?") + builder.DEFAULT_CLOSING);
+
+        modal = new Wirecloud.ui.AlertWindowMenu();
+        modal.setMsg(message);
+        modal.acceptHandler = function () {
+            this.behaviourEngine.removeConnection(connection, true);
+        }.bind(this);
+        modal.show();
     };
 
     var component_onremove = function component_onremove(component) {
@@ -785,7 +808,7 @@ Wirecloud.ui = Wirecloud.ui || {};
         }
     };
 
-    var connection_ondragstart = function connection_ondragstart(connectionEngine, connection, initialEndpoint) {
+    var connection_ondragstart = function connection_ondragstart(connectionEngine, connection, initialEndpoint, realEndpoint) {
         /*jshint validthis:true */
 
         this.collapsedComponents = [];
@@ -797,6 +820,11 @@ Wirecloud.ui = Wirecloud.ui || {};
                 this.collapsedComponents.push(component);
             }
         }.bind(this));
+
+        if (this.connectionEngine._connectionBackup != null) {
+            this.suggestionManager.hideSuggestions(realEndpoint);
+            this.suggestionManager.showSuggestions(initialEndpoint);
+        }
     };
 
     var connection_ondragend = function connection_ondragend(connectionEngine, connection, initialEndpoint) {

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/Connection.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/Connection.js
@@ -1,5 +1,5 @@
 /*
- *     Copyright (c) 2015 CoNWeT Lab., Universidad Politécnica de Madrid
+ *     Copyright (c) 2015-2016 CoNWeT Lab., Universidad Politécnica de Madrid
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -274,6 +274,15 @@
                 }
 
                 this.activeCount++;
+
+                return this;
+            },
+
+            click: function click() {
+
+                if (this.enabled) {
+                    this.trigger('click');
+                }
 
                 return this;
             },
@@ -644,8 +653,8 @@
         event.preventDefault();
         event.stopPropagation();
 
-        if (this.enabled && event.button === 0) {
-            this.trigger('click');
+        if (event.button === 0) {
+            this.click();
         }
     };
 

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/Endpoint.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/Endpoint.js
@@ -1,5 +1,5 @@
 /*
- *     Copyright (c) 2015 CoNWeT Lab., Universidad Politécnica de Madrid
+ *     Copyright (c) 2015-2016 CoNWeT Lab., Universidad Politécnica de Madrid
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -274,14 +274,17 @@
             },
 
             /**
-             * [TODO: hasEditableConnection description]
-             *
+             * @param {Connection} connection
              * @returns {Boolean}
-             *      [TODO: description]
              */
-            hasEditableConnection: function hasEditableConnection() {
-                return this.connections.some(function (connection) {
-                    return connection.editable;
+            hasConnection: function hasConnection(connection) {
+
+                if (!(connection instanceof ns.Connection)) {
+                    return false;
+                }
+
+                return this.connections.some(function (connectionSaved) {
+                    return connectionSaved.equals(connection);
                 });
             },
 

--- a/src/wirecloud/platform/wiring/tests.py
+++ b/src/wirecloud/platform/wiring/tests.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015 CoNWeT Lab., Universidad Politécnica de Madrid
+# Copyright (c) 2011-2016 CoNWeT Lab., Universidad Politécnica de Madrid
 
 # This file is part of Wirecloud.
 
@@ -854,8 +854,8 @@ class ComponentDraggableTestCase(WirecloudSeleniumTestCase):
             widget_1 = wiring.find_component_by_title('widget', 'Test 2')
             operator_2 = wiring.find_component_by_title('operator', 'TestOperator')
             widget_3 = wiring.find_component_by_title('widget', 'Test 1')
-            ActionChains(self.driver).key_down(Keys.COMMAND).click(widget_1.element).perform();
-            ActionChains(self.driver).click(operator_2.element).perform();
+            ActionChains(self.driver).key_down(Keys.COMMAND).click(widget_1.element).perform()
+            ActionChains(self.driver).click(operator_2.element).perform()
             ActionChains(self.driver).click(widget_3.element).key_up(Keys.COMMAND).perform()
 
             # Remove the selection using the backspace key
@@ -906,7 +906,6 @@ class ComponentMissingTestCase(WirecloudSeleniumTestCase):
             widget = wiring.find_component_by_title('widget', "Test")
             self.assertTrue(widget.missing)
             widget.show_menu_prefs().check(must_be_disabled=('Settings',)).close()
-
 
         with self.wiring_view as wiring:
             widget = wiring.find_component_by_title('widget', "Test")
@@ -1123,6 +1122,106 @@ class ConnectionManagementTestCase(WirecloudSeleniumTestCase):
         with self.wiring_view as wiring:
             self.assertEqual(len(wiring.find_connections()), 3)
             self.assertEqual(len(wiring.filter_connections_by_properties('missing')), 0)
+
+    def test_modify_connection(self):
+        self.login(username='user_with_workspaces')
+
+        with self.wiring_view as wiring:
+            connection = wiring.find_connection_by_endpoints('widget/2/outputendpoint', 'operator/0/input')
+            connection.click()
+            self.assertTrue(connection.active)
+
+            operator = wiring.find_component_by_id('operator', 0)
+            target1 = operator.find_endpoint_by_name('target', 'input')
+            target2 = operator.find_endpoint_by_name('target', 'nothandled')
+
+            widget1 = wiring.find_component_by_id('widget', 1)
+            target3 = widget1.find_endpoint_by_name('target', 'inputendpoint')
+
+            widget2 = wiring.find_component_by_id('widget', 2)
+            source1 = widget2.find_endpoint_by_name('source', 'outputendpoint')
+
+            connection.drag_endpoint(target1, target2)
+            self.assertTrue(connection.temporal)
+            self.assertFalse(target1.active)
+            self.assertTrue(target2.active)
+            self.assertTrue(target3.active)
+            self.assertTrue(source1.active)
+
+            connection.drop_endpoint()
+            self.assertIsNone(wiring.find_connection_by_endpoints('widget/2/outputendpoint', 'operator/0/input'))
+            self.assertIsNotNone(wiring.find_connection_by_endpoints('widget/2/outputendpoint', 'operator/0/nothandled'))
+
+    def test_modify_connection_on_several_behaviours(self):
+        self.login(username='user_with_workspaces', next='/user_with_workspaces/WorkspaceBehaviours')
+
+        with self.wiring_view as wiring:
+            connection = wiring.find_connection_by_endpoints('widget/11/outputendpoint', 'operator/0/input')
+            connection.click()
+            self.assertTrue(connection.active)
+
+            operator = wiring.find_component_by_id('operator', 0)
+            target1 = operator.find_endpoint_by_name('target', 'input')
+            target2 = operator.find_endpoint_by_name('target', 'nothandled')
+
+            widget1 = wiring.find_component_by_id('widget', 10)
+            target3 = widget1.find_endpoint_by_name('target', 'inputendpoint')
+
+            widget2 = wiring.find_component_by_id('widget', 11)
+            source1 = widget2.find_endpoint_by_name('source', 'outputendpoint')
+
+            connection.drag_endpoint(target1, target2)
+            self.assertTrue(connection.temporal)
+            self.assertFalse(target1.active)
+            self.assertTrue(target2.active)
+            self.assertTrue(target3.active)
+            self.assertTrue(source1.active)
+
+            connection.drop_endpoint()
+
+            # Now the connection belonging to other behaviours will also be removed. To do this,
+            # the following operation, shown in the window alert, will be accepted.
+            form = FormModalTester(self, self.wait_element_visible_by_css_selector(".wc-alert-dialog"))
+            form.accept()
+
+            self.assertIsNone(wiring.find_connection_by_endpoints('widget/2/outputendpoint', 'operator/0/input'))
+            self.assertIsNotNone(wiring.find_connection_by_endpoints('widget/11/outputendpoint', 'operator/0/nothandled'))
+
+    def test_modify_connection_on_active_behaviours(self):
+        self.login(username='user_with_workspaces', next='/user_with_workspaces/WorkspaceBehaviours')
+
+        with self.wiring_view as wiring:
+            connection = wiring.find_connection_by_endpoints('widget/11/outputendpoint', 'operator/0/input')
+            connection.click()
+            self.assertTrue(connection.active)
+
+            operator = wiring.find_component_by_id('operator', 0)
+            target1 = operator.find_endpoint_by_name('target', 'input')
+            target2 = operator.find_endpoint_by_name('target', 'nothandled')
+
+            widget1 = wiring.find_component_by_id('widget', 10)
+            target3 = widget1.find_endpoint_by_name('target', 'inputendpoint')
+
+            widget2 = wiring.find_component_by_id('widget', 11)
+            source1 = widget2.find_endpoint_by_name('source', 'outputendpoint')
+
+            connection.drag_endpoint(target1, target2)
+            self.assertTrue(connection.temporal)
+            self.assertFalse(target1.active)
+            self.assertTrue(target2.active)
+            self.assertTrue(target3.active)
+            self.assertTrue(source1.active)
+
+            connection.drop_endpoint()
+
+            # Now the connection belonging to other behaviours will be existing. To do this,
+            # the following operation, shown in the window alert, will be cacelled.
+            form = FormModalTester(self, self.wait_element_visible_by_css_selector(".wc-alert-dialog"))
+            form.cancel()
+
+            connection = wiring.find_connection_by_endpoints('widget/11/outputendpoint', 'operator/0/input')
+            self.assertTrue(connection.background)
+            self.assertIsNotNone(wiring.find_connection_by_endpoints('widget/11/outputendpoint', 'operator/0/nothandled'))
 
 
 @wirecloud_selenium_test_case


### PR DESCRIPTION
This pull-request resolves #91 Now you can select a connection and then, drag one of their endpoints to another possible endpoint. If the behaviour engine is enabled and such connection belongs to another behaviours, the platform will show a window menu asking you if you want to apply the same operation to the rest of behaviours.