### PR TITLE
Make all components not selectable

### DIFF
--- a/src/wirecloud/defaulttheme/static/css/wiring/wiring_components.scss
+++ b/src/wirecloud/defaulttheme/static/css/wiring/wiring_components.scss
@@ -20,6 +20,10 @@
             width: 85%;
         }
 
+        .panel-body {
+            @include user-select(none);
+        }
+
         .component-version-list {
             margin: 0 0 5px;
 


### PR DESCRIPTION
This pull-request fixes #109 and to do this, now you cannot select any component available from the drop zone (wiring view's sidebar related to components). But, it is allowed to select their titles.