### PR TITLE
WiringEditor: create and add any available widget

### DIFF
--- a/src/wirecloud/platform/static/js/dragboard/dragboard.js
+++ b/src/wirecloud/platform/static/js/dragboard/dragboard.js
@@ -294,9 +294,14 @@
                     iwidget = new IWidget(widget, layout, iwidgetinfo);
                     this.addIWidget(iwidget, options);
                     iwidget.paint();
+
+                    Wirecloud.Utils.callCallback(options.onSuccess, iwidget.internal_iwidget);
                 }.bind(this),
                 onFailure: function (response) {
-                    Wirecloud.GlobalLogManager.formatAndLog(gettext("Error adding iwidget to persistence: %(errorMsg)s."), response);
+                    var message = gettext("Error adding iwidget to persistence: %(errorMsg)s.");
+                    message = Wirecloud.GlobalLogManager.formatAndLog(message, response);
+
+                    Wirecloud.Utils.callCallback(options.onFailure, message);
                 }
             });
         };

--- a/src/wirecloud/platform/static/js/wirecloud/Widget.js
+++ b/src/wirecloud/platform/static/js/wirecloud/Widget.js
@@ -21,7 +21,7 @@
 
 /*global gettext, interpolate, Tab, StyledElements, Wirecloud*/
 
-(function () {
+(function (utils) {
 
     "use strict";
 
@@ -106,6 +106,7 @@
         };
 
         Wirecloud.WidgetBase.call(this, widget, tab, options);
+        this.logManager.log(utils.gettext("The widget was created successfully."), Wirecloud.constants.LOGGING.INFO_MSG);
     };
     Wirecloud.Utils.inherit(Widget, Wirecloud.WidgetBase);
 
@@ -196,4 +197,4 @@
 
     Wirecloud.Widget = Widget;
 
-})();
+})(StyledElements.Utils);

--- a/src/wirecloud/platform/static/js/wirecloud/WidgetMeta.js
+++ b/src/wirecloud/platform/static/js/wirecloud/WidgetMeta.js
@@ -85,7 +85,19 @@
                 var transObj = {vendor: this.vendor, name: this.name, version: this.version};
                 var msg = gettext("[Widget; Vendor: %(vendor)s, Name: %(name)s, Version: %(version)s]");
                 return utils.interpolate(msg, transObj, true);
+            },
+
+            /**
+             * Create a new instance of this WidgetMeta.
+             *
+             * @param {?Object} [options] options used for creating the instance
+             * @returns {Wirecloud.WidgetMeta} The instance on which this method is called.
+             */
+            instantiate: function instantiate(options) {
+                Wirecloud.activeWorkspace.addInstance(this, options);
+                return this;
             }
+
         }
     });
 

--- a/src/wirecloud/platform/static/js/wirecloud/Wiring.js
+++ b/src/wirecloud/platform/static/js/wirecloud/Wiring.js
@@ -126,6 +126,27 @@
                 return operator;
             },
 
+            /**
+             * Create a new instance of the given componentMeta.
+             *
+             * @param {(Wirecloud.wiring.OperatorMeta|Wirecloud.WidgetMeta)} componentMeta A valid component meta.
+             * @param {?Function} [next] A callback that receives the component created.
+             * @return {Wirecloud.Wiring} The instance on which this method is called.
+             */
+            createComponent: function createComponent(componentMeta, options) {
+                var newComponent;
+
+                if (componentMeta.type === 'operator') {
+                    newComponent = componentMeta.instantiate(this.autoOperatorId++, this);
+
+                    utils.callCallback(options.onSuccess, newComponent);
+                } else { // componentMeta.type === 'widget'
+                    componentMeta.instantiate(options);
+                }
+
+                return this;
+            },
+
             createConnection: function createConnection(readonly, source, target) {
                 return new ns.wiring.Connection(readonly, source, target, this);
             },

--- a/src/wirecloud/platform/static/js/wirecloud/Wiring.js
+++ b/src/wirecloud/platform/static/js/wirecloud/Wiring.js
@@ -62,6 +62,8 @@
                 workspace: {value: workspace}
             });
 
+            this.autoOperatorId = 1;
+
             this._widget_onadded = widget_onadded.bind(this);
             this._widget_onremoved = widget_onremoved.bind(this);
 
@@ -153,8 +155,14 @@
 
                 this.trigger('load');
 
+                this.autoOperatorId = 1;
+
                 for (id in status.operators) {
                     operator = status.operators[id];
+
+                    if (parseInt(id, 10) >= this.autoOperatorId) {
+                        this.autoOperatorId = parseInt(id, 10) + 1;
+                    }
 
                     if (id in old_operators) {
                         delete old_operators[id];

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
@@ -266,8 +266,8 @@ Wirecloud.ui = Wirecloud.ui || {};
             getComponentDraggable: function (component) {
                 return this.createComponent(component, {commit: false});
             }.bind(this),
-            createWiringComponent: function (meta) {
-                return meta.instantiate(this.workspace.wiring.autoOperatorId++, this.workspace.wiring);
+            createWiringComponent: function (meta, options) {
+                this.workspace.wiring.createComponent(meta, options);
             }.bind(this)
         });
 

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
@@ -62,7 +62,6 @@ Wirecloud.ui = Wirecloud.ui || {};
             this.selectedCount = 0;
 
             this.orderableComponent = null;
-            this.autoOperatorId = 1;
         },
 
         inherit: se.Alternative,
@@ -268,7 +267,7 @@ Wirecloud.ui = Wirecloud.ui || {};
                 return this.createComponent(component, {commit: false});
             }.bind(this),
             createWiringComponent: function (meta) {
-                return meta.instantiate(this.autoOperatorId++, this.workspace.wiring);
+                return meta.instantiate(this.workspace.wiring.autoOperatorId++, this.workspace.wiring);
             }.bind(this)
         });
 
@@ -438,7 +437,6 @@ Wirecloud.ui = Wirecloud.ui || {};
         this.suggestionManager.enable();
 
         this.orderableComponent = null;
-        this.autoOperatorId = 1;
 
         return this;
     };
@@ -564,10 +562,6 @@ Wirecloud.ui = Wirecloud.ui || {};
 
             if (!operatorsInUse[id].volatile) {
                 this.createComponent(operatorsInUse[id], vInfo.components.operator[id]);
-
-                if (parseInt(id, 10) >= this.autoOperatorId) {
-                    this.autoOperatorId = parseInt(id, 10) + 1;
-                }
             }
         }, this);
 

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
@@ -468,8 +468,7 @@ Wirecloud.ui = Wirecloud.ui || {};
         // ...completed.
 
         // Loading the operators uploaded in this account...
-        var operators = Wirecloud.wiring.OperatorFactory.getAvailableOperators();
-        loadOperators.call(this, operators, wiringEngine.operators, visualStatus);
+        loadOperators.call(this, wiringEngine.operators, visualStatus.components.operator);
         // ...completed.
 
         // Loading the connections established in the workspace...
@@ -547,41 +546,44 @@ Wirecloud.ui = Wirecloud.ui || {};
         return this;
     };
 
-    var loadOperators = function loadOperators(operators, operatorsInUse, vInfo) {
+    var loadOperators = function loadOperators(wiringOperators, visualOperators) {
         /*jshint validthis:true */
+        var metaOperators = Wirecloud.LocalCatalogue.getAvailableResourcesByType('operator');
+        var id, operator;
 
-        Object.keys(operators).forEach(function (uri) {
-            this.componentManager.addMeta(operators[uri]);
-        }, this);
+        for (id in metaOperators) {
+            this.componentManager.addMeta(metaOperators[id]);
+        }
 
-        Object.keys(operatorsInUse).forEach(function (id) {
+        for (id in wiringOperators) {
+            operator = wiringOperators[id];
 
-            if (!operatorsInUse[id].missing) {
-                this.componentManager.addWiringComponent(operatorsInUse[id]);
+            if (!operator.missing) {
+                this.componentManager.addWiringComponent(operator);
             }
 
-            if (!operatorsInUse[id].volatile) {
-                this.createComponent(operatorsInUse[id], vInfo.components.operator[id]);
+            if (!operator.volatile) {
+                this.createComponent(operator, visualOperators[operator.id]);
             }
-        }, this);
-
-        // TODO: for id vInfo.components.operator && operatorInfo.name != ""
+        }
 
         return this;
     };
 
     var loadWidgets = function loadWidgets(wiringWidgets, visualWidgets) {
         /*jshint validthis:true */
+        var metaWidgets = Wirecloud.LocalCatalogue.getAvailableResourcesByType('widget');
+        var id, widget;
 
-        var id, message, widget;
+        for (id in metaWidgets) {
+            this.componentManager.addMeta(metaWidgets[id]);
+        }
 
         for (id in wiringWidgets) {
             widget = wiringWidgets[id];
 
             if (!widget.missing) {
-                this.componentManager
-                    .addMeta(widget.meta)
-                    .addWiringComponent(widget);
+                this.componentManager.addWiringComponent(widget);
             }
 
             if (widget.id in visualWidgets) {

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ComponentGroup.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ComponentGroup.js
@@ -64,11 +64,7 @@
             this.currentVersion = null;
             this.latestVersion = null;
 
-            if (options.canCreate) {
-                this.meta.btnAdd.on('click', btncreate_onclick.bind(this));
-            } else {
-                this.meta.btnAdd.remove();
-            }
+            this.meta.btnAdd.on('click', btncreate_onclick.bind(this));
 
             Object.defineProperties(this, {
                 id: {value: meta.group_id},
@@ -147,11 +143,14 @@
     var defaults = {
         createWiringComponent: null,
         getComponentDraggable: null,
-        canCreate: false
     };
 
     var btncreate_onclick = function btncreate_onclick() {
-        this.appendWiringComponent(this.createWiringComponent(this.currentVersion));
+        this.createWiringComponent(this.currentVersion, {
+            onSuccess: function (wiringComponent) {
+                this.appendWiringComponent(wiringComponent);
+            }.bind(this)
+        });
     };
 
     var component_ondragstart = function component_ondragstart(draggable, context, event) {

--- a/src/wirecloud/platform/static/js/wirecloud/wiring/Operator.js
+++ b/src/wirecloud/platform/static/js/wirecloud/wiring/Operator.js
@@ -114,6 +114,8 @@
 
             build_endpoints.call(this);
             build_prefs.call(this, businessInfo.preferences);
+
+            this.logManager.log(utils.gettext("The operator was created successfully."), Wirecloud.constants.LOGGING.INFO_MSG);
         },
 
         inherit: se.ObjectWithEvents,

--- a/src/wirecloud/platform/wiring/tests.py
+++ b/src/wirecloud/platform/wiring/tests.py
@@ -979,6 +979,19 @@ class WiringBasicOperationTestCase(WirecloudSeleniumTestCase):
         self.assertEqual(len(alerts), count)
         dialog.accept()
 
+    def test_create_and_add_available_widget(self):
+        self.login(username='user_with_workspaces', next="user_with_workspaces/ExistingWorkspace")
+
+        self.assertEqual(len(self.get_current_iwidgets()), 0)
+
+        with self.wiring_view as wiring:
+            with wiring.component_sidebar as sidebar:
+                sidebar.create_and_add_component('widget', "Wirecloud/Test")
+
+        iwidgets = self.get_current_iwidgets()
+        self.assertEqual(len(iwidgets), 1)
+        self.assertEqual(iwidgets[0].name, "Test")
+
 
 @wirecloud_selenium_test_case
 class WiringRecoveringTestCase(WirecloudSeleniumTestCase):


### PR DESCRIPTION
This pull-request resolves #94 . Now you can see all available widgets/operators from the Wiring Editor view and then, create new instances of them. In the case of widgets, every widget created from Wiring Editor also create a visual interface in the default tab you have in your current workspace. 