### PR TITLE
Model tables not displaying 0. Fix #135

### DIFF
--- a/src/js_tests/ModelTableSpec.js
+++ b/src/js_tests/ModelTableSpec.js
@@ -1,0 +1,40 @@
+(function () {
+
+    "use strict";
+
+    describe("Styled ModelTable", function () {
+
+        var dom = null;
+
+        beforeEach(function () {
+            dom = document.createElement('div');
+            document.body.appendChild(dom);
+        });
+
+        afterEach(function () {
+            if (dom != null) {
+                dom.remove();
+                dom = null;
+            }
+        });
+
+        it("Test 0 number gets added", function () {
+            var columns = [
+                {field: "test", "label": "TestName", sortable: false, type: "number"},
+            ];
+            //Default options
+            var options = {};
+            //Create the table
+            var table = new StyledElements.ModelTable(columns, options);
+
+            //Create and push the data
+            var data = [
+                {test: 0}
+            ];
+            var keys = Object.keys(data[0]);
+            table.source.changeElements(data);
+
+            expect(table.columnsCells[0][0].innerHTML).toBe("0");
+        });
+    });
+})();

--- a/src/wirecloud/commons/static/js/StyledElements/ModelTable.js
+++ b/src/wirecloud/commons/static/js/StyledElements/ModelTable.js
@@ -139,7 +139,8 @@
                     cellContent = this.pGetFieldValue(item, column.field);
                 }
 
-                if (!cellContent) {
+                // If the cellContent is number 0 it should not be replaced.
+                if (!cellContent && !(column.type === "number" && cellContent === 0)) {
                     cellContent = '';
                 }
 


### PR DESCRIPTION
Change `ModelTable.js` to stop replacing `0` with `""` when it should not.

The new behavior only happens when the column type is `"number"`, so it should not alter any previous functionality for the other types, were them to be `0`.

Also added a test to check if this functionality is working properly.

This fixes #135 