### PR TITLE
Wiring Editor: use vertical layouts into panel sidebars

### DIFF
--- a/src/wirecloud/commons/utils/remote.py
+++ b/src/wirecloud/commons/utils/remote.py
@@ -1794,7 +1794,7 @@ class WiringBehaviourSidebarTester(BaseWiringViewTester):
 
     @property
     def panel(self):
-        return self.testcase.driver.find_element_by_css_selector(".panel-behaviours")
+        return self.testcase.driver.find_element_by_css_selector(".we-panel-behaviours")
 
     def create_behaviour(self, title=None, description=None):
         new_length = len(self.find_behaviours()) + 1

--- a/src/wirecloud/defaulttheme/static/css/styledelements/styled_panel.scss
+++ b/src/wirecloud/defaulttheme/static/css/styledelements/styled_panel.scss
@@ -60,10 +60,13 @@
     }
 }
 
+.panel-heading > :last-child {
+    margin-bottom: 0;
+}
+
 .panel-title {
     position: relative;
     display: block;
-    font-weight: "bold";
     overflow: hidden;
     margin-top: 0;
     margin-bottom: 0;

--- a/src/wirecloud/defaulttheme/static/css/wiring/wiring_layout.scss
+++ b/src/wirecloud/defaulttheme/static/css/wiring/wiring_layout.scss
@@ -26,57 +26,15 @@
 // WIRING SIDEBAR - PANEL
 // ============================================================================
 
-.wiring-sidebar > .panel {
-    @include positioned-element(0, 0, 0, 0);
-    margin-bottom: 0px;
-    background-color: $panel-default-heading-bg;
-    border-radius: 0px;
-    padding: $panel-padding-vertical $panel-padding-horizontal;
-    box-shadow: $panel-box-shadow;
-
-    & > .panel-heading {
-        padding: 0px 0px $panel-padding-vertical;
-        border-radius: 0px;
-    }
-
-    & > .panel-body {
-        @include positioned-element(40px, $panel-padding-horizontal, $panel-padding-vertical, $panel-padding-horizontal);
-        border: solid 1px $panel-default-border-color;
-        box-shadow: $panel-box-shadow-inset;
-        background-color: $panel-bg;
-        overflow-y: scroll;
-
-        .section {
-            position: relative;
-            display: block;
-        }
-    }
-}
-
-.wiring-sidebar > .panel-behaviours {
-
-    & > .panel-heading .panel-title {
-        float: left;
-        width: 90%;
-    }
-
-    &.disabled {
-        opacity: 1;
-    }
-}
-
 .we-panel-components {
 
     .se-text-field {
-        margin: 0 0 $margin-vertical-base;
+        margin: $margin-vertical-base 0;
         width: 100%;
     }
 
     .widget_wallet_list {
-        padding: ($panel-padding-horizontal / 2);
-        background-color: #FFF;
-        border: 1px solid $panel-default-border-color;
-        border-radius: ($panel-border-radius / 2);
+        position: relative;
 
         .alert {
             margin: 0 0 $margin-vertical-base;
@@ -84,10 +42,14 @@
     }
 }
 
-.wiring-sidebar > .panel-behaviours:not(.disabled) {
+.we-panel-behaviours {
 
-    & > .panel-body {
-        top: 80px;
+    .panel-heading .btn-group {
+        margin-top: $margin-vertical-base;
+    }
+
+    &.disabled {
+        opacity: 1;
     }
 }
 

--- a/src/wirecloud/defaulttheme/templates/wirecloud/wiring/behaviour_sidebar.html
+++ b/src/wirecloud/defaulttheme/templates/wirecloud/wiring/behaviour_sidebar.html
@@ -1,0 +1,13 @@
+{% load i18n %}
+<s:styledgui xmlns:s="http://wirecloud.conwet.fi.upm.es/StyledElements" xmlns:t="http://wirecloud.conwet.fi.upm.es/Template" xmlns="http://www.w3.org/1999/xhtml">
+<div class="panel panel-default se-vertical-layout we-panel-behaviours">
+    <div class="panel-heading se-vl-north-container">
+        <div class="panel-title">
+            <strong>{% trans "Behaviours" %}</strong>
+            <div class="panel-options"><t:btnenable/></div>
+        </div>
+        <div class="btn-group pull-right"><t:buttons/></div>
+    </div>
+    <t:panelbody/>
+</div>
+</s:styledgui>

--- a/src/wirecloud/defaulttheme/templates/wirecloud/wiring/component_sidebar.html
+++ b/src/wirecloud/defaulttheme/templates/wirecloud/wiring/component_sidebar.html
@@ -5,14 +5,16 @@
     <s:options>{"class": "panel panel-default we-panel-components"}</s:options>
 
     <s:northcontainer>
-        <div class="panel-heading">
-            <div class="panel-title">{% trans "Components" %}</div>
+        <s:options>{"class": "panel-heading"}</s:options>
+        <div class="panel-title">
+            <strong>{% trans "Components" %}</strong>
         </div>
         <t:searchinput/>
         <div class="btn-group btn-group-justified"><t:buttons/></div>
     </s:northcontainer>
 
     <s:centercontainer>
+        <s:options>{"class": "panel-body"}</s:options>
         <t:list/>
     </s:centercontainer>
 

--- a/src/wirecloud/platform/core/plugins.py
+++ b/src/wirecloud/platform/core/plugins.py
@@ -556,6 +556,7 @@ class WirecloudCorePlugin(WirecloudPlugin):
     def get_templates(self, view):
         if view == 'classic':
             return {
+                "behaviour_sidebar": "wirecloud/wiring/behaviour_sidebar.html",
                 "component_group": "wirecloud/wiring/component_group.html",
                 "component_sidebar": "wirecloud/wiring/component_sidebar.html",
                 "embed_code_dialog": "wirecloud/ui/embed_code_dialog.html",

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
@@ -52,8 +52,8 @@ Wirecloud.ui = Wirecloud.ui || {};
 
             createAndSetUpLayout.call(this);
 
+            Wirecloud.addEventListener('loaded', createAndSetUpBehaviourEngine.bind(this));
             Wirecloud.addEventListener('loaded', createAndSetUpComponentManager.bind(this));
-            createAndSetUpBehaviourEngine.call(this);
             createAndSetUpConnectionEngine.call(this);
 
             this.suggestionManager = new ns.WiringEditor.KeywordSuggestion();

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js
@@ -39,6 +39,7 @@
     ns.BehaviourEngine = utils.defineClass({
 
         constructor: function BehaviourEngine() {
+            this.superClass(events);
             var note;
 
             this.btnEnable = new se.Button({
@@ -48,16 +49,7 @@
             });
             this.btnEnable.on('click', btnenable_onclick.bind(this));
 
-            this.superClass({
-                events: events,
-                extraClass: "panel-behaviours",
-                title: gettext("Behaviours"),
-                buttons: [this.btnEnable]
-            });
-
-            this.btnGroupElement = document.createElement('div');
-            this.btnGroupElement.className = "btn-group pull-right";
-            this.wrapperElement.appendChild(this.btnGroupElement);
+            this.body = new se.Container({class: "panel-body se-vl-center-container"});
 
             this.btnCreate = new se.Button({
                 title: gettext("Create behaviour"),
@@ -65,7 +57,6 @@
                 iconClass: "icon-plus"
             });
             this.btnCreate.on('click', btncreate_onclick.bind(this));
-            this.btnCreate.appendTo(this.btnGroupElement);
 
             this.btnOrder = new se.ToggleButton({
                 title: gettext("Order behaviours"),
@@ -73,8 +64,13 @@
                 iconClass: "icon-sort"
             });
             this.btnOrder.on('click', btnorder_onclick.bind(this));
-            this.btnOrder.appendTo(this.btnGroupElement);
             this.btnOrder.disable();
+
+            this.wrapperElement = (new se.GUIBuilder()).parse(Wirecloud.currentTheme.templates.behaviour_sidebar, {
+                btnenable: this.btnEnable,
+                buttons: new se.Fragment([this.btnCreate, this.btnOrder]),
+                panelbody: this.body
+            }).children[1];
 
             Object.defineProperties(this, {
                 orderingEnabled: {
@@ -101,7 +97,7 @@
             this.components = {operator: {}, widget: {}};
         },
 
-        inherit: se.Panel,
+        inherit: se.StyledElement,
 
         statics: {
 
@@ -124,14 +120,14 @@
                         .replaceIconClass('icon-lock', 'icon-unlock');
                     this.btnCreate.show();
                     this.body.removeChild(this.disabledAlert);
-                    this.wrapperElement.appendChild(this.btnGroupElement);
+                    this.btnCreate.get().parentElement.classList.remove('hidden');
                 } else {
                     this.btnEnable
                         .setTitle(gettext("Enable"))
                         .replaceIconClass('icon-unlock', 'icon-lock');
                     this.btnCreate.hide();
                     this.body.appendChild(this.disabledAlert);
-                    this.wrapperElement.removeChild(this.btnGroupElement);
+                    this.btnCreate.get().parentElement.classList.add('hidden');
                     this.stopOrdering();
                 }
 


### PR DESCRIPTION
This pull-request closes #157 
Now, the panel sidebars from Wiring Editor use the vertical layout's  CSS rules.