### PR TITLE
Add ordered tabs with no add button

### DIFF
--- a/src/js_tests/NotebookSpec.js
+++ b/src/js_tests/NotebookSpec.js
@@ -43,6 +43,16 @@
 
         it("should add a new tab", function () {
             var element = new StyledElements.Notebook();
+            var tab1 = element.createTab();
+            var tab2 = element.createTab();
+
+            expect(element.tabs).toEqual([tab1, tab2]);
+            expect(element.tabArea.wrapperElement.children[0]).toBe(tab1.tabElement);
+            expect(element.tabArea.wrapperElement.children[1]).toBe(tab2.tabElement);
+        });
+
+        it("should add a new tab when add button exists", function () {
+            var element = new StyledElements.Notebook();
 
             element.addEventListener('newTab', function () {});
 

--- a/src/wirecloud/commons/static/js/StyledElements/Notebook.js
+++ b/src/wirecloud/commons/static/js/StyledElements/Notebook.js
@@ -353,7 +353,13 @@
         this.tabsById[tabId] = tab;
 
         var tabElement = tab.getTabElement();
-        this.tabArea.prependChild(tabElement, this.new_tab_button_tabs);
+
+        if (this.new_tab_button_tabs != null) {
+            this.tabArea.prependChild(tabElement, this.new_tab_button_tabs);
+        } else {
+            this.tabArea.appendChild(tabElement);
+        }
+
         tab.insertInto(this.contentArea);
         if (this.maxTabElementWidth == null) {
             this._computeMaxTabElementWidth();


### PR DESCRIPTION
This pull-request fixes #146 
The problem was that was not taken into consideration when the nootbook did not have the add button, as a result the tabs were added at the beginning.