### PR TITLE
Wiring Editor: disallow background connection modifications

### DIFF
--- a/src/wirecloud/defaulttheme/static/css/wiring/wiring_layout.scss
+++ b/src/wirecloud/defaulttheme/static/css/wiring/wiring_layout.scss
@@ -1,5 +1,6 @@
 @import 'wiring/defaults';
 @import 'utils';
+@import "compass/css3/user-interface";
 @import "variables";
 
 // ============================================================================
@@ -64,87 +65,30 @@
     box-shadow: $panel-box-shadow;
     color: $panel-default-heading-text-color;
     text-shadow: $text-shadow-conf-base rgba(contrast-color($panel-default-heading-bg, #FFF, #000, $text-color-threshold), 0.8);
+    @include user-select(none);
+    padding: 0 $panel-padding-horizontal;
 
-    .wiring-logger {
-        @include positioned-element($top: 0, $bottom: 0, $left: 0);
-        height: 20px;
-        margin: auto $panel-padding-horizontal;
-
-        span {
-            display: block;
-            white-space: nowrap;
-            overflow: hidden;
-            max-width: 250px;
-        }
-    }
-
-    .wiring-legend {
-        @include positioned-element($top: 0, $bottom: 0, $right: 0);
-        height: 20px;
-        margin: auto $panel-padding-horizontal;
+    .se-horizontal-layout {
+        height: 100%;
+        align-items: center;
     }
 }
 
 // ============================================================================
-// WIRING-FOOTER - LEGEND ELEMENTS
+// WIRING LEGEND - LABELS
 // ============================================================================
 
-.wiring-footer .wiring-element {
-    display: inline-block;
-    font-weight: "bold";
-    vertical-align: middle;
-    margin: 0px ($panel-padding-horizontal * 2) 0px 0px;
-
-    &:last-child {
-        margin-right: 0px;
-    }
-
-    .color {
-        padding: 0px $panel-padding-horizontal;
-        color: rgb(255, 255, 255);
-        border: solid 1px transparent;
-        border-radius: $panel-border-radius;
-        box-sizing: border-box;
-        text-shadow: none;
-    }
-
-    .title {
-        margin-left: ($panel-padding-horizontal / 2);
-    }
+.label-connection {
+    color: $text-color-dark;
+    background-color: $connection-bg;
 }
 
-// ============================================================================
-// WIRING-FOOTER - LEGEND CONNECTIONS
-// ============================================================================
-
-.wiring-footer .element-connection {
-
-    .color {
-        background-color: $connection-bg;
-        border-color: $connection-bg;
-    }
+.label-operator {
+    color: $text-color-dark;
+    background-color: $component-operator-bg;
 }
 
-// ============================================================================
-// WIRING-FOOTER - LEGEND OPERATORS
-// ============================================================================
-
-.wiring-footer .element-operator {
-
-    .color {
-        background-color: $component-operator-bg;
-        border-color: $component-operator-border-color;
-    }
-}
-
-// ============================================================================
-// WIRING-FOOTER - LEGEND WIDGETS
-// ============================================================================
-
-.wiring-footer .element-widget {
-
-    .color {
-        background-color: $component-widget-bg;
-        border-color: $component-widget-border-color;
-    }
+.label-widget {
+    color: $text-color-dark;
+    background-color: $component-widget-bg;
 }

--- a/src/wirecloud/defaulttheme/templates/wirecloud/wiring/wiring_footer.html
+++ b/src/wirecloud/defaulttheme/templates/wirecloud/wiring/wiring_footer.html
@@ -1,0 +1,17 @@
+{% load i18n %}
+<s:styledgui xmlns:s="http://wirecloud.conwet.fi.upm.es/StyledElements" xmlns:t="http://wirecloud.conwet.fi.upm.es/Template" xmlns="http://www.w3.org/1999/xhtml">
+<s:horizontallayout>
+    <s:centercontainer><t:title/></s:centercontainer>
+    <s:eastcontainer>
+        <span class="label label-connection">
+            <t:connections/> {% trans "Connections" %}
+        </span>
+        <span class="label label-operator">
+            <t:operators/> {% trans "Operators" %}
+        </span>
+        <span class="label label-widget">
+            <t:widgets/> {% trans "Widgets" %}
+        </span>
+    </s:eastcontainer>
+</s:horizontallayout>
+</s:styledgui>

--- a/src/wirecloud/platform/core/plugins.py
+++ b/src/wirecloud/platform/core/plugins.py
@@ -575,6 +575,7 @@ class WirecloudCorePlugin(WirecloudPlugin):
                 "wallet": "wirecloud/workspace/wallet/wallet.html",
                 "wallet_widget": "wirecloud/workspace/wallet/widget.html",
                 "wirecloud_catalogue_upload_dialog": "wirecloud/catalogue/upload_dialog.html",
+                "wiring_footer": "wirecloud/wiring/wiring_footer.html",
                 "upgrade_window_menu": "wirecloud/ui/upgrade_window_menu.html",
             }
         else:

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
@@ -331,41 +331,24 @@ Wirecloud.ui = Wirecloud.ui || {};
                 }
             }.bind(this));
 
-        var wiringLegend = document.createElement('div');
-
-        wiringLegend.className = "wiring-legend";
-        wiringLegend.innerHTML =
-            '<span class="wiring-element element-connection">' +
-                '<span class="color"></span>' +
-                '<span class="title">' + utils.gettext("Connections") + '</span>' +
-            '</span>' +
-            '<span class="wiring-element element-operator">' +
-                '<span class="color"></span>' +
-                '<span class="title">' + utils.gettext("Operators") + '</span>' +
-            '</span>' +
-            '<span class="wiring-element element-widget">' +
-                '<span class="color"></span>' +
-                '<span class="title">' + utils.gettext("Widgets") + '</span>' +
-            '</span>';
-
-        var wiringLogger = document.createElement('div');
-        var currentBehaviour = document.createElement('span');
-
-        wiringLogger.className = 'wiring-logger';
-        wiringLogger.appendChild(currentBehaviour);
-
         this.legend = {
-            title: currentBehaviour,
-            connections: wiringLegend.querySelector('.element-connection .color'),
-            operators: wiringLegend.querySelector('.element-operator .color'),
-            widgets: wiringLegend.querySelector('.element-widget .color')
+            title: document.createElement('span'),
+            connections: document.createElement('span'),
+            operators: document.createElement('span'),
+            widgets: document.createElement('span')
         };
 
-        this.layout.footer
-            .appendChild(wiringLogger)
-            .appendChild(wiringLegend);
+        Wirecloud.addEventListener('loaded', function () {
+            this.layout.footer.appendChild((new se.GUIBuilder()).parse(Wirecloud.currentTheme.templates.wiring_footer, {
+                title: this.legend.title,
+                connections: this.legend.connections,
+                operators: this.legend.operators,
+                widgets: this.legend.widgets
+            }).children[1]);
+        }.bind(this));
 
         this.layout.content.get().addEventListener('click', layout_onclick.bind(this));
+        this.layout.content.get().addEventListener('dblclick', layout_ondblclick.bind(this));
         this.appendChild(this.layout);
 
         return this;

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
@@ -794,7 +794,6 @@ Wirecloud.ui = Wirecloud.ui || {};
     var connection_onclick = function connection_onclick(connectionEngine, connectionClicked) {
         /*jshint validthis:true */
 
-        this.layout.slideOut();
         clearComponentSelection.call(this);
 
         if (this.orderableComponent != null) {
@@ -855,10 +854,6 @@ Wirecloud.ui = Wirecloud.ui || {};
     var layout_onclick = function layout_onclick() {
         /*jshint validthis:true */
 
-        var type, id;
-
-        this.layout.slideOut();
-
         clearComponentSelection.call(this);
 
         if (this.orderableComponent != null) {
@@ -867,6 +862,11 @@ Wirecloud.ui = Wirecloud.ui || {};
         }
 
         this.connectionEngine.setUp();
+    };
+
+    var layout_ondblclick = function layout_ondblclick() {
+        /*jshint validthis:true */
+        this.layout.slideOut();
     };
 
     var showSelectedPanel = function showSelectedPanel(button, panelIndex) {

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js
@@ -202,6 +202,8 @@
             notifyErrors.call(this);
             makeDraggable.call(this);
 
+            this.wrapperElement.addEventListener('dblclick', utils.stopPropagationListener);
+
             wiringComponent.on('upgraded', this._component_onupgrade_bound);
         },
 

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/Connection.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/Connection.js
@@ -45,6 +45,8 @@
             this.wrapperElement = document.createElementNS(ns.Connection.SVG_NS, 'g');
             this.wrapperElement.setAttribute('class', "connection");
             this.wrapperElement.addEventListener('click', connection_onclick.bind(this));
+            this.wrapperElement.addEventListener('dblclick', utils.stopPropagationListener);
+
             this.wrapperElement.addEventListener('mouseenter', connection_onmouseenter.bind(this));
             this.wrapperElement.addEventListener('mouseleave', connection_onmouseleave.bind(this));
 

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ConnectionEngine.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ConnectionEngine.js
@@ -337,9 +337,14 @@
         }
 
         if (endpoint.hasConnection(this.activeConnection)) {
-            this.activeConnection.addClassName('temporal');
-            initialEndpoint = this.activeConnection[opposites[endpoint.type]].endpoint;
-            this._connectionBackup = this.activeConnection;
+            if (this.activeConnection.background) {
+                this.activeConnection.click();
+                initialEndpoint = endpoint;
+            } else {
+                this.activeConnection.addClassName('temporal');
+                initialEndpoint = this.activeConnection[opposites[endpoint.type]].endpoint;
+                this._connectionBackup = this.activeConnection;
+            }
         } else {
             initialEndpoint = endpoint;
         }

--- a/src/wirecloud/platform/wiring/tests.py
+++ b/src/wirecloud/platform/wiring/tests.py
@@ -1536,6 +1536,25 @@ class ConnectionManagementTestCase(WirecloudSeleniumTestCase):
             self.assertTrue(wiring.find_connection('widget/11/outputendpoint', 'operator/0/input').has_class('background'))
             self.assertIsNotNone(wiring.find_connection('widget/11/outputendpoint', 'operator/0/nothandled'))
 
+    def test_modify_connection_on_background_is_not_allowed(self):
+        self.login(username='user_with_workspaces', next='/user_with_workspaces/WorkspaceBehaviours')
+
+        with self.wiring_view as wiring:
+            operator = wiring.find_draggable_component('operator', id=0)
+            source = operator.find_endpoint('source', 'output')
+
+            widget = wiring.find_draggable_component('widget', title="Test 1")
+            target = widget.find_endpoint('target', 'nothandled')
+
+            connection1 = wiring.find_connection('operator/0/output', 'widget/10/inputendpoint')
+            connection1.click()
+
+            connection2 = source.create_connection(target)
+
+            self.assertTrue(connection1.has_class('background'))
+            self.assertFalse(connection1.has_class('active'))
+            self.assertIsNotNone(connection2)
+
 
 @wirecloud_selenium_test_case
 class EndpointManagementTestCase(WirecloudSeleniumTestCase):


### PR DESCRIPTION
This pull-request fixes #153 

When you are in the wiring editor and have the behaviour engine enabled, now you cannot already modify any connection that is not belonging to the current behaviour.

There is also an improvement in the handle of the event 'click' from the wiring editor. If you want to close the panel sidebar using a shortcut, you can use the double click inside the wiring container to close it.