### PR TITLE
Wiring Editor: panel of components is cleared before loading the view

### DIFF
--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
@@ -421,7 +421,7 @@ Wirecloud.ui = Wirecloud.ui || {};
         this.layout.slideOut();
 
         this.behaviourEngine.clear().disable();
-
+        this.componentManager.clear();
         this.suggestionManager.enable();
 
         this.orderableComponent = null;

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ComponentShowcase.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ComponentShowcase.js
@@ -128,7 +128,8 @@
         },
 
         clear: function clear() {
-            this.components = {};
+            this.searchComponents._list.clear();
+            this.components = {operator: {}, widget: {}};
             return this;
         },
 
@@ -165,6 +166,11 @@
             delete this.components[type][group_id][component.id];
 
             return this;
+        },
+
+        show: function show() {
+            this.searchComponents.refresh();
+            return se.StyledElement.prototype.show.call(this);
         }
 
     });

--- a/src/wirecloud/platform/wiring/tests.py
+++ b/src/wirecloud/platform/wiring/tests.py
@@ -1246,6 +1246,28 @@ class ComponentDraggableTestCase(WirecloudSeleniumTestCase):
                 self.assertIsNotNone(alert)
                 self.assertTrue(alert.has_class('alert-info'))
 
+    @uses_extra_workspace('user_with_workspaces', 'Wirecloud_mashup-with-behaviours_1.0.wgt', shared=True)
+    def test_check_component_sidebar(self):
+        self.login(username='user_with_workspaces', next='/user_with_workspaces/mashup-with-behaviours')
+        self._check_component_sidebar()
+        # Get back to dashboard
+        self._check_component_sidebar()
+
+    def _check_component_sidebar(self):
+        with self.wiring_view as wiring:
+            with wiring.component_sidebar as sidebar:
+                widgets = sidebar.find_components('widget', "Wirecloud/Test")
+                self.assertEqual(len(widgets), 2)
+                self.assertEqual(widgets[0].title, "Test 1")
+                self.assertEqual(widgets[0].state, "in use")
+                self.assertEqual(widgets[1].title, "Test 2")
+                self.assertEqual(widgets[1].state, "in use")
+
+                operators = sidebar.find_components('operator', "Wirecloud/TestOperator")
+                self.assertEqual(len(operators), 1)
+                self.assertEqual(operators[0].title, "TestOperator")
+                self.assertEqual(operators[0].state, "in use")
+
 
 @wirecloud_selenium_test_case
 class ComponentMissingTestCase(WirecloudSeleniumTestCase):


### PR DESCRIPTION
The panel of components never cleared the components used in the wiring. So, if you exited and then entered the wiring editor, the old references to the componentes kept appearing in such panel.

Now, the panel of components is cleaned up before loading the wiring editor view.