### PR TITLE
Wiring Editor: Not refresh components search after adding a component

### DIFF
--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
@@ -378,6 +378,9 @@ Wirecloud.ui = Wirecloud.ui || {};
             stackedIconClass: "icon-plus-sign"
         });
         this.btnFindComponents.on('click', function (button) {
+            if (button.active) {
+                this.componentManager.searchComponents.refresh();
+            }
             showSelectedPanel.call(this, button, 1);
         }.bind(this));
 

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ComponentShowcase.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ComponentShowcase.js
@@ -166,11 +166,6 @@
             delete this.components[type][group_id][component.id];
 
             return this;
-        },
-
-        show: function show() {
-            this.searchComponents.refresh();
-            return se.StyledElement.prototype.show.call(this);
         }
 
     });


### PR DESCRIPTION
The issue was that the components search was refreshed after adding a component and this was a weird behaviour. Now, after adding a component the last position in the panel of components is kept.