### PR TITLE
Wiring Editor: keep the state active in modified connections

### DIFF
--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ConnectionEngine.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ConnectionEngine.js
@@ -400,6 +400,11 @@
                 .stickEndpoint(finalEndpoint)
                 .createAndBind(false, this.wiringEngine);
             appendConnection.call(this, this.temporalConnection, this._connectionBackup);
+
+            if (this._connectionBackup != null) {
+                this.temporalConnection.click();
+            }
+
             break;
         case ns.ConnectionEngine.CONNECTION_DUPLICATE:
             this.trigger('duplicate', this.temporalInitialEndpoint.getConnectionTo(finalEndpoint));

--- a/src/wirecloud/platform/wiring/tests.py
+++ b/src/wirecloud/platform/wiring/tests.py
@@ -1521,7 +1521,9 @@ class ConnectionManagementTestCase(WirecloudSeleniumTestCase):
             connection.change_endpoint(target1, target2)
 
             self.assertIsNone(wiring.find_connection('widget/2/outputendpoint', 'operator/0/input'))
-            self.assertIsNotNone(wiring.find_connection('widget/2/outputendpoint', 'widget/1/inputendpoint'))
+            connection = wiring.find_connection('widget/2/outputendpoint', 'widget/1/inputendpoint')
+            self.assertIsNotNone(connection)
+            self.assertTrue(connection.has_class('active'))
 
     def test_modify_connection_on_several_behaviours(self):
         self.login(username='user_with_workspaces', next='/user_with_workspaces/WorkspaceBehaviours')
@@ -1539,7 +1541,9 @@ class ConnectionManagementTestCase(WirecloudSeleniumTestCase):
             modal.accept()
 
             self.assertIsNone(wiring.find_connection('widget/11/outputendpoint', 'operator/0/input'))
-            self.assertIsNotNone(wiring.find_connection('widget/11/outputendpoint', 'operator/0/nothandled'))
+            connection = wiring.find_connection('widget/11/outputendpoint', 'operator/0/nothandled')
+            self.assertIsNotNone(connection)
+            self.assertTrue(connection.has_class('active'))
 
     def test_modify_connection_on_active_behaviours(self):
         self.login(username='user_with_workspaces', next='/user_with_workspaces/WorkspaceBehaviours')
@@ -1556,7 +1560,9 @@ class ConnectionManagementTestCase(WirecloudSeleniumTestCase):
             modal.cancel()
 
             self.assertTrue(wiring.find_connection('widget/11/outputendpoint', 'operator/0/input').has_class('background'))
-            self.assertIsNotNone(wiring.find_connection('widget/11/outputendpoint', 'operator/0/nothandled'))
+            connection = wiring.find_connection('widget/11/outputendpoint', 'operator/0/nothandled')
+            self.assertIsNotNone(connection)
+            self.assertTrue(connection.has_class('active'))
 
     def test_modify_connection_on_background_is_not_allowed(self):
         self.login(username='user_with_workspaces', next='/user_with_workspaces/WorkspaceBehaviours')


### PR DESCRIPTION
This pull request fixes #174 Now after modifying the connection's endpoint, such connection will be in state 'active'.