### PR TITLE
Wiring Editor: modify connection and then drop it over connection on background

### DIFF
--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
@@ -721,11 +721,15 @@ Wirecloud.ui = Wirecloud.ui || {};
         behaviour_onchange.call(this, behaviourEngine, currentStatus, true);
     };
 
-    var connection_onduplicate = function connection_onduplicate(connectionEngine, connection) {
+    var connection_onduplicate = function connection_onduplicate(connectionEngine, connection, connectionBackup) {
         /*jshint validthis:true */
 
         if (connection.background) {
             this.behaviourEngine.updateConnection(connection, connection.toJSON(), true);
+
+            if (connectionBackup != null) {
+                removeBackupConnection.call(this, connectionBackup);
+            }
         }
     };
 
@@ -746,11 +750,15 @@ Wirecloud.ui = Wirecloud.ui || {};
             }.bind(this));
 
         if (connectionBackup != null) {
-            this.behaviourEngine.removeConnection(connectionBackup);
+            removeBackupConnection.call(this, connectionBackup);
+        }
+    };
 
-            if (this.behaviourEngine.hasConnection(connectionBackup)) {
-                showConnectionChangeModal.call(this, connectionBackup);
-            }
+    var removeBackupConnection = function removeBackupConnection(connection) {
+        this.behaviourEngine.removeConnection(connection);
+
+        if (this.behaviourEngine.hasConnection(connection)) {
+            showConnectionChangeModal.call(this, connection);
         }
     };
 

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ConnectionEngine.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ConnectionEngine.js
@@ -402,7 +402,7 @@
             appendConnection.call(this, this.temporalConnection, this._connectionBackup);
             break;
         case ns.ConnectionEngine.CONNECTION_DUPLICATE:
-            this.trigger('duplicate', this.temporalInitialEndpoint.getConnectionTo(finalEndpoint));
+            this.trigger('duplicate', this.temporalInitialEndpoint.getConnectionTo(finalEndpoint), this._connectionBackup);
             /* falls through */
         default:
             this.temporalConnection.remove();

--- a/src/wirecloud/platform/wiring/tests.py
+++ b/src/wirecloud/platform/wiring/tests.py
@@ -1577,6 +1577,22 @@ class ConnectionManagementTestCase(WirecloudSeleniumTestCase):
             self.assertFalse(connection1.has_class('active'))
             self.assertIsNotNone(connection2)
 
+    def test_modify_connection_and_drop_over_connection_on_background(self):
+        self.login(username='user_with_workspaces', next='/user_with_workspaces/WorkspaceBehaviours')
+
+        with self.wiring_view as wiring:
+            operator = wiring.find_draggable_component('operator', id=0)
+            widget = wiring.find_draggable_component('widget', title="Test 1")
+
+            source1 = operator.find_endpoint('source', 'output')
+            target1 = widget.find_endpoint('target', 'inputendpoint')
+            target2 = widget.find_endpoint('target', 'nothandled')
+            connection = source1.create_connection(target2)
+            connection.change_endpoint(target2, target1)
+
+            self.assertIsNone(wiring.find_connection(source1.id, target2.id))
+            self.assertFalse(wiring.find_connection(source1.id, target1.id).has_class('background'))
+
 
 @wirecloud_selenium_test_case
 class EndpointManagementTestCase(WirecloudSeleniumTestCase):


### PR DESCRIPTION
This pull-request fixes #175 The issue was that the wiring editor disallowed to combine the following actions: modify and duplicate connections.
Now you can drop the connection to be modified over another connection on background. And doing this, you will duplicate the connection on background and then modify the connection.