### PR TITLE
Wiring Editor: maintain the selection after modifiying a connection

### DIFF
--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
@@ -324,7 +324,7 @@ Wirecloud.ui = Wirecloud.ui || {};
             }.bind(this))
             .on('slideIn', function (offcanvas, panel) {
                 this.btnFindComponents.active = panel.hasClassName("we-panel-components");
-                this.btnListBehaviours.active = panel.hasClassName("panel-behaviours");
+                this.btnListBehaviours.active = panel.hasClassName("we-panel-behaviours");
 
                 if (this.btnFindComponents.active) {
                     this.behaviourEngine.stopOrdering();

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
@@ -347,8 +347,9 @@ Wirecloud.ui = Wirecloud.ui || {};
             }).children[1]);
         }.bind(this));
 
-        this.layout.content.get().addEventListener('click', layout_onclick.bind(this));
         this.layout.content.get().addEventListener('dblclick', layout_ondblclick.bind(this));
+        this.layout.content.get().addEventListener('mousedown', layout_onclick.bind(this));
+
         this.appendChild(this.layout);
 
         return this;

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/Connection.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/Connection.js
@@ -45,7 +45,8 @@
             this.wrapperElement = document.createElementNS(ns.Connection.SVG_NS, 'g');
             this.wrapperElement.setAttribute('class', "connection");
             this.wrapperElement.addEventListener('click', connection_onclick.bind(this));
-            this.wrapperElement.addEventListener('dblclick', utils.stopPropagationListener);
+            this.wrapperElement.addEventListener('dblclick', utils.stopPropagationListener, true);
+            this.wrapperElement.addEventListener('mousedown', utils.stopPropagationListener, true);
 
             this.wrapperElement.addEventListener('mouseenter', connection_onmouseenter.bind(this));
             this.wrapperElement.addEventListener('mouseleave', connection_onmouseleave.bind(this));

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ConnectionEngine.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ConnectionEngine.js
@@ -378,7 +378,9 @@
     };
 
     var connection_ondragend = function connection_ondragend(event) {
-        endpoint_ondragend.call(this, null);
+        event.preventDefault();
+        event.stopPropagation();
+        endpoint_ondragend.call(this);
     };
 
     var endpoint_ondragend = function endpoint_ondragend(finalEndpoint) {
@@ -407,9 +409,15 @@
 
             break;
         case ns.ConnectionEngine.CONNECTION_DUPLICATE:
-            this.trigger('duplicate', this.temporalInitialEndpoint.getConnectionTo(finalEndpoint), this._connectionBackup);
-            /* falls through */
+            this.temporalConnection.remove();
+            this.trigger('duplicate', this.temporalInitialEndpoint.getConnectionTo(finalEndpoint).click(), this._connectionBackup);
+            break;
         default:
+
+            if (this._connectionBackup != null) {
+                this._connectionBackup.click();
+            }
+
             this.temporalConnection.remove();
             this.trigger('cancel');
         }

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/Endpoint.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/Endpoint.js
@@ -416,6 +416,7 @@
 
         if (this.enabled && event.button === 0) {
             event.stopPropagation();
+            event.preventDefault();  // Required for disabling text selection
             this.trigger('mouseup', event);
         }
     };


### PR DESCRIPTION
This pull-request fixes #174 
The issue was because of the capture of the event 'click'. When you dropped the connection which was being modified, the event 'click' was dispatched and in some occasions, the layout of the wiring editor could listen too. As a result, the wiring editor stopped modifying such connection.