### PR TITLE
Wiring Editor: upgrade missing components

### DIFF
--- a/src/wirecloud/platform/static/js/wirecloud/WidgetBase.js
+++ b/src/wirecloud/platform/static/js/wirecloud/WidgetBase.js
@@ -250,9 +250,14 @@
         }
 
         if (this.meta.missing) {
-            this.logManager.log(utils.gettext('Missing widget: This widget is currently not available. Probably you or an administrator uninstalled it.'), {details: new se.Fragment("<h5>Suggestions:</h5><ul><li>Remove this widget from the dashboard</li><li>Reinstall the appropiated version of the widget</li><li>Install another version of the widget and use the <em>Upgrade/Downgrade</em> option</li></ul>")});
+            this.logManager.log(utils.gettext("Failed to load widget."), {
+                level: Wirecloud.constants.LOGGING.ERROR_MSG,
+                details: new se.Fragment(utils.gettext("<p>The widget is currently not available. You or an administrator probably uninstalled or delete it.</p><h5>Suggestions:</h5><ul><li>Remove the widget.</li><li>Upload the same version of the widget.</li><li>Or upload another version of the widget and then use the <em>Upgrade/Downgrade</em> option.</li></ul>"))
+            });
         } else {
-            this.logManager.log(utils.gettext('Widget loaded successfully'), Wirecloud.constants.LOGGING.INFO_MSG);
+            this.logManager.log(utils.gettext("The widget was loaded successfully."), {
+                level: Wirecloud.constants.LOGGING.INFO_MSG
+            });
         }
 
         this.loaded = true;
@@ -288,7 +293,9 @@
             return;
         }
 
-        this.logManager.log(utils.gettext('Widget unloaded'), Wirecloud.constants.LOGGING.INFO_MSG);
+        this.logManager.log(utils.gettext("The widget was unloaded successfully."), {
+            level: Wirecloud.constants.LOGGING.INFO_MSG
+        });
         this.logManager.newCycle();
 
         // Remove context callbacks

--- a/src/wirecloud/platform/static/js/wirecloud/Wiring.js
+++ b/src/wirecloud/platform/static/js/wirecloud/Wiring.js
@@ -189,10 +189,6 @@
                         delete old_operators[id];
                     }
 
-                    if (operator.missing) {
-                        this.logManager.log(operator.reason);
-                    }
-
                     operator
                         .on('upgraded', component_onupgraded.bind(this))
                         .on('unload', component_onunload)

--- a/src/wirecloud/platform/static/js/wirecloud/ui/UpgradeWindowMenu.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/UpgradeWindowMenu.js
@@ -1,5 +1,5 @@
 /*
- *     Copyright (c) 2015 CoNWeT Lab., Universidad Politécnica de Madrid
+ *     Copyright (c) 2015-2016 CoNWeT Lab., Universidad Politécnica de Madrid
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -127,17 +127,18 @@
             var new_component = Wirecloud.LocalCatalogue.getResourceId(new_component_id);
 
             var _onsuccess_listener = function onsuccess_listener() {
+                var msg = utils.interpolate(utils.gettext("The %(type)s's version was changed successfully."), {type: component.meta.type});
+
                 component.removeEventListener('upgraded', _onsuccess_listener);
                 component.removeEventListener('upgradeerror', _onfailure_listener);
 
-                var msg;
-                if (new_version.compareTo(old_version) > 0) {
-                    msg = utils.gettext("The %(type)s was upgraded to v%(version)s successfully.");
-                } else {
-                    msg = utils.gettext("The %(type)s was downgraded to v%(version)s successfully.");
-                }
-                msg = utils.interpolate(msg, {type: component.meta.type, version: new_version});
-                component.logManager.log(msg, Wirecloud.constants.LOGGING.INFO_MSG);
+                component.logManager.log(msg, {
+                    level: Wirecloud.constants.LOGGING.INFO_MSG,
+                    details: new se.Fragment(utils.interpolate(utils.gettext("<p>Now the %(type)s's version is <strong>%(version)s</strong>.</p>"), {
+                        type: component.meta.type,
+                        version: new_version
+                    }))
+                });
 
                 this._closeListener();
             }.bind(this);

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
@@ -454,12 +454,12 @@ Wirecloud.ui = Wirecloud.ui || {};
         wiringEngine = this.workspace.wiring;
         visualStatus = wiringEngine.status.visualdescription;
 
-        // Loading the widgets used in the workspace...
-        loadWidgets.call(this, wiringEngine.widgets, visualStatus.components.widget);
+        // Loading the widgets used in this workspace...
+        loadComponents.call(this, wiringEngine.widgets, visualStatus.components.widget);
         // ...completed.
 
-        // Loading the operators uploaded in this account...
-        loadOperators.call(this, wiringEngine.operators, visualStatus.components.operator);
+        // Loading the operators used in this workspace...
+        loadComponents.call(this, wiringEngine.operators, visualStatus.components.operator);
         // ...completed.
 
         // Loading the connections established in the workspace...
@@ -537,40 +537,16 @@ Wirecloud.ui = Wirecloud.ui || {};
         return this;
     };
 
-    var loadOperators = function loadOperators(wiringOperators, visualOperators) {
+    var loadComponents = function loadComponents(components, visualInfo) {
         /*jshint validthis:true */
-        var metaOperators = Wirecloud.LocalCatalogue.getAvailableResourcesByType('operator');
-        var id, operator;
+        var id, component;
 
-        for (id in wiringOperators) {
-            operator = wiringOperators[id];
+        for (id in components) {
+            component = components[id];
+            this.componentManager.addComponent(component);
 
-            if (!operator.missing) {
-                this.componentManager.addComponent(operator);
-            }
-
-            if (!operator.volatile) {
-                this.createComponent(operator, visualOperators[operator.id]);
-            }
-        }
-
-        return this;
-    };
-
-    var loadWidgets = function loadWidgets(wiringWidgets, visualWidgets) {
-        /*jshint validthis:true */
-        var metaWidgets = Wirecloud.LocalCatalogue.getAvailableResourcesByType('widget');
-        var id, widget;
-
-        for (id in wiringWidgets) {
-            widget = wiringWidgets[id];
-
-            if (!widget.missing) {
-                this.componentManager.addComponent(widget);
-            }
-
-            if (widget.id in visualWidgets) {
-                this.createComponent(widget, visualWidgets[widget.id]);
+            if (component.id in visualInfo) {
+                this.createComponent(component, visualInfo[component.id]);
             }
         }
 
@@ -793,7 +769,9 @@ Wirecloud.ui = Wirecloud.ui || {};
             this.selectedCount--;
         }
 
-        if (!component.missing) {
+        if (component.missing) {
+            this.componentManager.removeComponent(component.type, component._component);
+        } else {
             this.componentManager.findComponent(component.type, component.id).enable();
         }
 

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/Component.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/Component.js
@@ -78,13 +78,22 @@
                 wiringComponent.on('title_changed', component_onrename.bind(this));
             }
 
-            if (wiringComponent.volatile || !wiringComponent.hasEndpoints()) {
+            if (wiringComponent.volatile || wiringComponent.missing) {
                 this.disable();
             }
 
             wiringComponent.on('upgraded', function (componentUpdated) {
                 this.setTitle(componentUpdated.title);
                 this.setSubtitle("v" + componentUpdated.meta.version.text);
+
+                if (this._missing) {
+                    this._missing = false;
+                    if (this._used) {
+                        formatDisabledMessage.call(this);
+                    } else {
+                        this.enable();
+                    }
+                }
             }.bind(this));
         },
 
@@ -101,6 +110,7 @@
                     formatDisabledMessage.call(this);
                     this.heading.appendChild(this.label);
                 } else {
+                    this._used = false;
                     this.heading.removeChild(this.label);
                 }
 
@@ -153,17 +163,15 @@
         if (this._component.volatile) {
             this.label.textContent = utils.gettext("volatile");
             this.label.className = "label label-info";
-            return this;
+        } else if (this._component.missing) {
+            this._missing = true;
+            this.label.textContent = utils.gettext("missing");
+            this.label.className = "label label-danger";
+        } else {
+            this._used = true;
+            this.label.textContent = utils.gettext("in use");
+            this.label.className = "label label-success";
         }
-
-        if (!this._component.hasEndpoints()) {
-            this.label.textContent = utils.gettext("no endpoints");
-            this.label.className = "label label-warning";
-            return this;
-        }
-
-        this.label.textContent = utils.gettext("in use");
-        this.label.className = "label label-success";
 
         return this;
     };

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js
@@ -95,7 +95,9 @@
                     set: function set(value) {this._oncollapsed(value);}
                 },
 
-                missing: {value: wiringComponent.missing},
+                missing: {
+                    get: function get() {return this._component.missing;}
+                },
 
                 readonly: {
                     get: function get() {return this.hasClassName('readonly');},
@@ -177,13 +179,11 @@
             appendEndpoints.call(this, 'source', wiringComponent.meta.outputList.map(function (data) {return wiringComponent.outputs[data.name];}));
             appendEndpoints.call(this, 'target', wiringComponent.meta.inputList.map(function (data) {return wiringComponent.inputs[data.name];}));
 
-            if (!this.missing) {
-                wiringComponent.logManager.addEventListener('newentry', notifyErrors.bind(this));
+            wiringComponent.logManager.addEventListener('newentry', notifyErrors.bind(this));
 
+            if (!this.missing) {
                 this.endpoints.source.orderEndpoints(options.endpoints.source);
                 this.endpoints.target.orderEndpoints(options.endpoints.target);
-            } else {
-                this.addClassName("missing");
             }
 
             if (options.collapsed) {
@@ -514,6 +514,7 @@
             },
 
             refresh: function refresh() {
+                notifyErrors.call(this);
                 return this.forEachEndpoint(function (endpoint) {
                     endpoint.refresh();
                 });
@@ -725,11 +726,13 @@
         var title, label, count;
 
         count = this._component.logManager.getErrorCount();
-        if (count || this.missing) {
+        this.toggleClassName('missing', this.missing);
 
-            if (!this.heading.has(this.heading.notice)) {
-                this.heading.appendChild(this.heading.notice);
-            }
+        if (this.heading.has(this.heading.notice)) {
+            this.heading.removeChild(this.heading.notice);
+        }
+
+        if (count || this.missing) {
 
             if (this.missing) {
                 title = utils.gettext("Missing");
@@ -741,6 +744,7 @@
             }
 
             this.heading.noticeTitle.textContent = title;
+            this.heading.appendChild(this.heading.notice);
         }
     };
 

--- a/src/wirecloud/platform/static/js/wirecloud/wiring/Operator.js
+++ b/src/wirecloud/platform/static/js/wirecloud/wiring/Operator.js
@@ -357,8 +357,9 @@
         this.pending_events.forEach(send_pending_event, this);
         this.pending_events = [];
 
-        var msg = utils.interpolate(utils.gettext("The operator (%(title)s) was loaded."), this);
-        this.logManager.log(msg, Wirecloud.constants.LOGGING.INFO_MSG);
+        this.logManager.log(utils.gettext("The operator was loaded successfully."), {
+            level: Wirecloud.constants.LOGGING.INFO_MSG
+        });
         this.trigger('load');
     };
 
@@ -366,8 +367,9 @@
 
         this.loaded = false;
 
-        var msg = utils.interpolate(utils.gettext("The operator (%(title)s) was unloaded."), this);
-        this.logManager.log(msg, Wirecloud.constants.LOGGING.INFO_MSG);
+        this.logManager.log(utils.gettext("The operator was unloaded successfully."), {
+            level: Wirecloud.constants.LOGGING.INFO_MSG
+        });
         this.trigger('unload');
     };
 

--- a/src/wirecloud/platform/static/js/wirecloud/wiring/Operator.js
+++ b/src/wirecloud/platform/static/js/wirecloud/wiring/Operator.js
@@ -357,9 +357,17 @@
         this.pending_events.forEach(send_pending_event, this);
         this.pending_events = [];
 
-        this.logManager.log(utils.gettext("The operator was loaded successfully."), {
-            level: Wirecloud.constants.LOGGING.INFO_MSG
-        });
+        if (this.missing) {
+            this.logManager.log(utils.gettext("Failed to load operator."), {
+                level: Wirecloud.constants.LOGGING.ERROR_MSG,
+                details: new se.Fragment(utils.gettext("<p>The operator is currently not available. You or an administrator probably uninstalled or delete it.</p><h5>Suggestions:</h5><ul><li>Remove the operator.</li><li>Upload the same version of the operator.</li><li>Or upload another version of the operator and then use the <em>Upgrade/Downgrade</em> option.</li></ul>"))
+            });
+        } else {
+            this.logManager.log(utils.gettext("The operator was loaded successfully."), {
+                level: Wirecloud.constants.LOGGING.INFO_MSG
+            });
+        }
+
         this.trigger('load');
     };
 
@@ -370,6 +378,7 @@
         this.logManager.log(utils.gettext("The operator was unloaded successfully."), {
             level: Wirecloud.constants.LOGGING.INFO_MSG
         });
+        this.logManager.newCycle();
         this.trigger('unload');
     };
 

--- a/src/wirecloud/platform/wiring/tests.py
+++ b/src/wirecloud/platform/wiring/tests.py
@@ -1125,7 +1125,7 @@ class ComponentDraggableTestCase(WirecloudSeleniumTestCase):
                 operator.change_version("2.0")
                 self.assertEqual(operator.version, "v2.0")
                 modal = operator.show_logs()
-                WebDriverWait(self.driver, timeout=5).until(lambda driver: len(modal.find_alerts(title="The operator was upgraded to v2.0 successfully.")) == 1)
+                WebDriverWait(self.driver, timeout=5).until(lambda driver: len(modal.find_alerts(title="The operator's version was changed successfully.")) == 1)
                 modal.accept()
             draggable_operator = wiring.find_draggable_component('operator', id=operator.id)
 
@@ -1153,7 +1153,7 @@ class ComponentDraggableTestCase(WirecloudSeleniumTestCase):
                 widget.change_version("3.0")
                 self.assertEqual(widget.version, "v3.0")
                 modal = widget.show_logs()
-                WebDriverWait(self.driver, timeout=5).until(lambda driver: len(modal.find_alerts(title="The widget was upgraded to v3.0 successfully.")) == 1)
+                WebDriverWait(self.driver, timeout=5).until(lambda driver: len(modal.find_alerts(title="The widget's version was changed successfully.")) == 1)
                 modal.accept()
             draggable_widget = wiring.find_draggable_component('widget', id=widget.id)
 
@@ -1180,7 +1180,7 @@ class ComponentDraggableTestCase(WirecloudSeleniumTestCase):
             draggable_widget.change_version("3.0")
             draggable_widget.change_version("1.0")
             modal = draggable_widget.show_logs()
-            WebDriverWait(self.driver, timeout=5).until(lambda driver: len(modal.find_alerts(title="The widget was downgraded to v1.0 successfully.")) == 1)
+            WebDriverWait(self.driver, timeout=5).until(lambda driver: len(modal.find_alerts(title="The widget's version was changed successfully.")) == 2)
             modal.accept()
 
             self.assertEqual(len(draggable_widget.find_endpoints('target')), 2)

--- a/src/wirecloud/platform/wiring/tests.py
+++ b/src/wirecloud/platform/wiring/tests.py
@@ -1355,6 +1355,18 @@ class ComponentMissingTestCase(WirecloudSeleniumTestCase):
             self._check_operator_missing(wiring, 1, 1, 1)
             self.assertEqual(len(wiring.find_connections(extra_class="missing")), 3)
 
+    @uses_extra_resources(('Wirecloud_TestOperator_2.0.zip',), shared=True)
+    def test_upgrade_missing_operator(self):
+        CatalogueResource.objects.get(vendor="Wirecloud", short_name="TestOperator", version="1.0").delete()
+        self.login(username='user_with_workspaces')
+
+        with self.wiring_view as wiring:
+            operator = wiring.find_draggable_component('operator', id=0)
+            self.assertTrue(operator.has_class('missing'))
+
+            operator.change_version("2.0")
+            self.assertFalse(operator.has_class('missing'))
+
 
 @wirecloud_selenium_test_case
 class ComponentOperatorTestCase(WirecloudSeleniumTestCase):


### PR DESCRIPTION
This pull-request fixes #181 

The issue was because of the missing components could not change their missing status. When a missing component was created and then was updated, such component loaded the configuration of that version properly but kept the missing status.