### PR TITLE
WiringEditor: a better solution to keep the selection of connections

### DIFF
--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
@@ -348,7 +348,8 @@ Wirecloud.ui = Wirecloud.ui || {};
         }.bind(this));
 
         this.layout.content.get().addEventListener('dblclick', layout_ondblclick.bind(this));
-        this.layout.content.get().addEventListener('mousedown', layout_onclick.bind(this));
+        this._layout_onclick = layout_onclick.bind(this);
+        this.layout.content.get().addEventListener('click', this._layout_onclick);
 
         this.appendChild(this.layout);
 
@@ -831,6 +832,8 @@ Wirecloud.ui = Wirecloud.ui || {};
             this.suggestionManager.hideSuggestions(realEndpoint);
             this.suggestionManager.showSuggestions(initialEndpoint);
         }
+
+        this.layout.content.get().removeEventListener('click', this._layout_onclick);
     };
 
     var connection_ondragend = function connection_ondragend(connectionEngine, connection, initialEndpoint) {
@@ -846,6 +849,10 @@ Wirecloud.ui = Wirecloud.ui || {};
         }
 
         this.suggestionManager.hideSuggestions(initialEndpoint);
+
+        setTimeout(function () {
+            this.layout.content.get().addEventListener('click', this._layout_onclick);
+        }.bind(this), 0);
     };
 
     var behaviour_onchange = function behaviour_onchange(behaviourEngine, currentStatus, enabled) {

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/Connection.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor/Connection.js
@@ -46,7 +46,6 @@
             this.wrapperElement.setAttribute('class', "connection");
             this.wrapperElement.addEventListener('click', connection_onclick.bind(this));
             this.wrapperElement.addEventListener('dblclick', utils.stopPropagationListener, true);
-            this.wrapperElement.addEventListener('mousedown', utils.stopPropagationListener, true);
 
             this.wrapperElement.addEventListener('mouseenter', connection_onmouseenter.bind(this));
             this.wrapperElement.addEventListener('mouseleave', connection_onmouseleave.bind(this));


### PR DESCRIPTION
Fixes #174 
A better solution is the following idea:
- When the dragend event of the connection engine is dispatched, the event listener attached to the click event of the wiring layout is removed.
- And then, such event listener is attached again to the same event through a setTimeout.