### PR TITLE
Model table multiple select

### DIFF
--- a/src/js_tests/es6-weakmap.js
+++ b/src/js_tests/es6-weakmap.js
@@ -1,0 +1,47 @@
+
+/*
+ * Copyright 2012 The Polymer Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
+if (typeof WeakMap === 'undefined') {
+  (function() {
+    var defineProperty = Object.defineProperty;
+    var counter = Date.now() % 1e9;
+
+    var WeakMap = function() {
+      this.name = '__st' + (Math.random() * 1e9 >>> 0) + (counter++ + '__');
+    };
+
+    WeakMap.prototype = {
+      set: function(key, value) {
+        var entry = key[this.name];
+        if (entry && entry[0] === key)
+          entry[1] = value;
+        else
+          defineProperty(key, this.name, {value: [key, value], writable: true});
+        return this;
+      },
+      get: function(key) {
+        var entry;
+        return (entry = key[this.name]) && entry[0] === key ?
+            entry[1] : undefined;
+      },
+      delete: function(key) {
+        var entry = key[this.name];
+        if (!entry) return false;
+        var hasValue = entry[0] === key;
+        entry[0] = entry[1] = undefined;
+        return hasValue;
+      },
+      has: function(key) {
+        var entry = key[this.name];
+        if (!entry) return false;
+        return entry[0] === key;
+      }
+    };
+
+    window.WeakMap = WeakMap;
+  })();
+}

--- a/src/js_tests/styledelements/ModelTableSpec.js
+++ b/src/js_tests/styledelements/ModelTableSpec.js
@@ -374,7 +374,6 @@
                     {id: 0}
                 ];
                 table.source.changeElements(data);
-                rows = table.wrapperElement.querySelectorAll(".se-model-table-row");
 
                 expect(function () {table.select(0);}).toThrow(new Error("Selection is disabled"));
 
@@ -405,7 +404,6 @@
                     {id: 1}
                 ];
                 table.source.changeElements(data);
-                rows = table.wrapperElement.querySelectorAll(".se-model-table-row");
 
                 expect(function () {table.select([0, 1]);}).toThrow(new Error("Selection is set to \"single\" but tried to select 2 rows."));
             });

--- a/src/js_tests/styledelements/ModelTableSpec.js
+++ b/src/js_tests/styledelements/ModelTableSpec.js
@@ -349,7 +349,7 @@
                 ];
 
                 // Create a new table
-                table = new StyledElements.ModelTable(columns, {id: 'id'});
+                table = new StyledElements.ModelTable(columns, {id: 'id', allowMultipleSelect: true});
 
                 // Create and push the data
                 var data = [

--- a/src/js_tests/styledelements/ModelTableSpec.js
+++ b/src/js_tests/styledelements/ModelTableSpec.js
@@ -415,7 +415,7 @@
                     // Check if css are applied properly
                     expected = [true, false, false];
                     observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                    expect(observed).toEqual(observed);
+                    expect(observed).toEqual(expected);
                 });
 
                 describe("should allow click selections with control key pressed", function () {
@@ -428,7 +428,7 @@
                         // Check if css are applied properly
                         expected = [true, false, false];
                         observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(observed);
+                        expect(observed).toEqual(expected);
                     });
 
                     it("should allow multiple selection", function () {
@@ -444,7 +444,7 @@
                         // Check if css are applied properly
                         expected = [true, false, true];
                         observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(observed);
+                        expect(observed).toEqual(expected);
                     });
 
                     it("should allow diselect selected rows", function () {
@@ -459,7 +459,7 @@
                         // Check if css are applied properly
                         expected = [false, false, false];
                         observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(observed);
+                        expect(observed).toEqual(expected);
                     });
                 });
 
@@ -473,7 +473,7 @@
                         // Check if css are applied properly
                         expected = [true, false, false];
                         observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(observed);
+                        expect(observed).toEqual(expected);
                     });
 
                     it("should allow range selection", function () {
@@ -489,7 +489,7 @@
                         // Check if css are applied properly
                         expected = [true, true, true];
                         observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(observed);
+                        expect(observed).toEqual(expected);
                     });
 
                     it("should overwrite previous selection", function () {
@@ -510,7 +510,7 @@
                         // Check if css are applied properly
                         expected = [false, true, true];
                         observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(observed);
+                        expect(observed).toEqual(expected);
                     });
                 });
 
@@ -525,7 +525,7 @@
                         // Check if css are applied properly
                         expected = [true, false, false];
                         observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(observed);
+                        expect(observed).toEqual(expected);
                     });
 
                     it("should allow range selection", function () {
@@ -542,7 +542,7 @@
                         // Check if css are applied properly
                         expected = [true, true, true];
                         observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(observed);
+                        expect(observed).toEqual(expected);
                     });
 
                     it("should not overwrite previous selection", function () {
@@ -558,12 +558,13 @@
                         cell = rows[2].querySelector(".se-model-table-cell");
                         event = new Event("click");
                         event.shiftKey = true;
+                        event.ctrlKey = true;
                         cell.dispatchEvent(event);
 
                         // Check if css are applied properly
                         expected = [true, true, true];
                         observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(observed);
+                        expect(observed).toEqual(expected);
                     });
                 });
 
@@ -580,14 +581,14 @@
 
                     expected = [true, true, true];
                     observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                    expect(observed).toEqual(observed);
+                    expect(observed).toEqual(expected);
 
                     table.wrapperElement.click();
 
                     // Check if css are applied properly
                     expected = [false, false, false];
                     observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                    expect(observed).toEqual(observed);
+                    expect(observed).toEqual(expected);
 
                 });
             });

--- a/src/js_tests/styledelements/ModelTableSpec.js
+++ b/src/js_tests/styledelements/ModelTableSpec.js
@@ -19,7 +19,7 @@
  *
  */
 
-/* globals StyledElements */
+/* globals StyledElements*/
 
 
 (function () {
@@ -92,107 +92,111 @@
             table = null;
         });
 
-        it("can be created using the minimal required info", function () {
-            var columns = [
-                {field: "test", type: "string"}
-            ];
+        describe("new ModelTable(columns, [options])", function () {
 
-            // Create a new table using the default options
-            table = new StyledElements.ModelTable(columns);
+            it("can be created using the minimal required info", function () {
+                var columns = [
+                    {field: "test", type: "string"}
+                ];
 
-            expect(table).not.toBe(null);
-        });
+                // Create a new table using the default options
+                table = new StyledElements.ModelTable(columns);
 
-        it("can be created providing exta CSS classes", function () {
-            var columns = [
-                {field: "test", type: "string"}
-            ];
+                expect(table).not.toBe(null);
+            });
 
-            var options = {
-                class: "my-css-class"
-            };
+            it("can be created providing exta CSS classes", function () {
+                var columns = [
+                    {field: "test", type: "string"}
+                ];
 
-            // Create a new table
-            table = new StyledElements.ModelTable(columns, options);
+                var options = {
+                    class: "my-css-class"
+                };
 
-            expect(table.wrapperElement.classList.contains('my-css-class')).toBeTruthy();
-        });
+                // Create a new table
+                table = new StyledElements.ModelTable(columns, options);
 
-        it("can be created providing exta CSS classes for the columns", function () {
-            var columns = [
-                {field: "test", type: "string", class: "my-css-class"}
-            ];
+                expect(table.wrapperElement.classList.contains('my-css-class')).toBeTruthy();
+            });
 
-            var options = {
-                class: "my-css-class"
-            };
+            it("can be created providing exta CSS classes for the columns", function () {
+                var columns = [
+                    {field: "test", type: "string", class: "my-css-class"}
+                ];
 
-            // Create a new table
-            table = new StyledElements.ModelTable(columns, options);
+                var options = {
+                    class: "my-css-class"
+                };
 
-            // Create and push the data
-            var data = [
-                {test: "Hello"},
-                {test: "world"}
-            ];
-            table.source.changeElements(data);
+                // Create a new table
+                table = new StyledElements.ModelTable(columns, options);
 
-            var column = table.wrapperElement.querySelectorAll(".my-css-class");
-            expect(column.length).toBe(3); // 1 header + 2 rows
-        });
+                // Create and push the data
+                var data = [
+                    {test: "Hello"},
+                    {test: "world"}
+                ];
+                table.source.changeElements(data);
 
-        it("can be created with custom cell width", function () {
-            var columns = [
-                {field: "test", type: "string", width: "100px"}
-            ];
+                var column = table.wrapperElement.querySelectorAll(".my-css-class");
+                expect(column.length).toBe(3); // 1 header + 2 rows
+            });
 
-            var options = {
-                initialSortColumn: "test2"
-            };
+            it("can be created with custom cell width", function () {
+                var columns = [
+                    {field: "test", type: "string", width: "100px"}
+                ];
 
-            table = new StyledElements.ModelTable(columns, options);
+                var options = {
+                    initialSortColumn: "test2"
+                };
 
-            // Create and push the data
-            var data = [
-                {test: "Hello"},
-                {test: "world"}
-            ];
-            table.source.changeElements(data);
+                table = new StyledElements.ModelTable(columns, options);
 
-            var column = table.wrapperElement.querySelectorAll(".se-model-table-cell");
+                // Create and push the data
+                var data = [
+                    {test: "Hello"},
+                    {test: "world"}
+                ];
+                table.source.changeElements(data);
 
-            expect(column.length).toBe(3);
-            for (var i = 0; i < column.length; i++) {
-                expect(column[i].style.width).toBe("100px");
-            }
+                var column = table.wrapperElement.querySelectorAll(".se-model-table-cell");
 
-        });
+                expect(column.length).toBe(3);
+                for (var i = 0; i < column.length; i++) {
+                    expect(column[i].style.width).toBe("100px");
+                }
 
-        it("can be created using the initialSortColumn option", function () {
+            });
 
-            var columns = [
-                {field: "test", type: "string", sortable: true},
-                {field: "test2", type: "string", sortable: true}
-            ];
+            it("can be created using the initialSortColumn option", function () {
 
-            var options = {
-                initialSortColumn: "test2"
-            };
+                var columns = [
+                    {field: "test", type: "string", sortable: true},
+                    {field: "test2", type: "string", sortable: true}
+                ];
 
-            // Create a new table
-            table = new StyledElements.ModelTable(columns, options);
+                var options = {
+                    initialSortColumn: "test2"
+                };
 
-            // Create and push the data
-            var data = [
-                {test: "a", test2: "b"},
-                {test: "b", test2: "a"}
-            ];
-            table.source.changeElements(data);
+                // Create a new table
+                table = new StyledElements.ModelTable(columns, options);
 
-            // Check if data was sorted correctly
-            var column = table.wrapperElement.querySelectorAll(".se-model-table-row .se-model-table-cell:first-child");
-            var observed = Array.prototype.map.call(column, function (cell) {return cell.innerHTML;});
-            expect(observed).toEqual(["b", "a"]);
+                // Create and push the data
+                var data = [
+                    {test: "a", test2: "b"},
+                    {test: "b", test2: "a"}
+                ];
+                table.source.changeElements(data);
+
+                // Check if data was sorted correctly
+                var column = table.wrapperElement.querySelectorAll(".se-model-table-row .se-model-table-cell:first-child");
+                var observed = Array.prototype.map.call(column, function (cell) {return cell.innerHTML;});
+                expect(observed).toEqual(["b", "a"]);
+            });
+
         });
 
         it("should handle data added to the data source", function () {
@@ -339,7 +343,7 @@
             });
         });
 
-        describe("should handle element selection", function () {
+        describe("select(selection)", function () {
             var expected, observed, rows;
             beforeEach(function () {
 
@@ -367,7 +371,7 @@
                 ];
 
                 // Create a new table
-                table = new StyledElements.ModelTable(columns, {id: 'id', selectionType: "ignore"});
+                table = new StyledElements.ModelTable(columns, {id: 'id', selectionType: "none"});
 
                 // Create and push the data
                 var data = [
@@ -405,7 +409,7 @@
                 ];
                 table.source.changeElements(data);
 
-                expect(function () {table.select([0, 1]);}).toThrow(new Error("Selection is set to \"single\" but tried to select 2 rows."));
+                expect(function () {table.select([0, 1]);}).toThrow(new Error("Selection is set to \"single\" but tried to select more than one rows."));
             });
 
             it("should allow multiple selections", function () {
@@ -440,12 +444,48 @@
                 expect(observed).toEqual(expected);
             });
 
-            describe("Should handle mouse to select", function () {
-                var cell, event;
+        });
 
-                it("should allow click selections without modifiers", function () {
+        describe("Should handle mouse to select", function () {
+            var expected, observed, rows;
+            beforeEach(function () {
+
+                var columns = [
+                    {field: "id", type: "number"},
+                    {field: "test", type: "number"}
+                ];
+
+                // Create a new table
+                table = new StyledElements.ModelTable(columns, {id: 'id', selectionType: "multiple"});
+
+                // Create and push the data
+                var data = [
+                    {id: 0, test: "hello world"},
+                    {id: 1, test: "bye world"},
+                    {id: 2, test: "other world"}
+                ];
+                table.source.changeElements(data);
+                rows = table.wrapperElement.querySelectorAll(".se-model-table-row");
+            });
+
+            var cell, event;
+
+            it("should allow click selections without modifiers", function () {
+                cell = rows[0].querySelector(".se-model-table-cell");
+                event = new MouseEvent("click");
+                cell.dispatchEvent(event);
+
+                // Check if css are applied properly
+                expected = [true, false, false];
+                observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                expect(observed).toEqual(expected);
+            });
+
+            describe("should allow click selections with control key pressed", function () {
+
+                it("should allow first selection", function () {
                     cell = rows[0].querySelector(".se-model-table-cell");
-                    event = new Event("click");
+                    event = new MouseEvent("click", {ctrlKey: true});
                     cell.dispatchEvent(event);
 
                     // Check if css are applied properly
@@ -454,181 +494,153 @@
                     expect(observed).toEqual(expected);
                 });
 
-                describe("should allow click selections with control key pressed", function () {
-
-                    it("should allow first selection", function () {
-                        cell = rows[0].querySelector(".se-model-table-cell");
-                        event = new Event("click");
-                        event.ctrlKey = true;
-                        cell.dispatchEvent(event);
-
-                        // Check if css are applied properly
-                        expected = [true, false, false];
-                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(expected);
-                    });
-
-                    it("should allow multiple selection", function () {
-                        cell = rows[0].querySelector(".se-model-table-cell");
-                        event = new Event("click");
-                        cell.dispatchEvent(event);
-
-                        cell = rows[2].querySelector(".se-model-table-cell");
-                        event = new Event("click");
-                        event.ctrlKey = true;
-                        cell.dispatchEvent(event);
-
-                        // Check if css are applied properly
-                        expected = [true, false, true];
-                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(expected);
-                    });
-
-                    it("should allow diselect selected rows", function () {
-                        cell = rows[0].querySelector(".se-model-table-cell");
-                        event = new Event("click");
-                        cell.dispatchEvent(event);
-
-                        event = new Event("click");
-                        event.ctrlKey = true;
-                        cell.dispatchEvent(event);
-
-                        // Check if css are applied properly
-                        expected = [false, false, false];
-                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(expected);
-                    });
-                });
-
-                describe("should allow click selections with shift key pressed", function () {
-                    it("should allow first selection", function () {
-                        cell = rows[0].querySelector(".se-model-table-cell");
-                        event = new Event("click");
-                        event.shiftKey = true;
-                        cell.dispatchEvent(event);
-
-                        // Check if css are applied properly
-                        expected = [true, false, false];
-                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(expected);
-                    });
-
-                    it("should allow range selection", function () {
-                        cell = rows[0].querySelector(".se-model-table-cell");
-                        event = new Event("click");
-                        cell.dispatchEvent(event);
-
-                        cell = rows[2].querySelector(".se-model-table-cell");
-                        event = new Event("click");
-                        event.shiftKey = true;
-                        cell.dispatchEvent(event);
-
-                        // Check if css are applied properly
-                        expected = [true, true, true];
-                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(expected);
-                    });
-
-                    it("should overwrite previous selection", function () {
-                        cell = rows[0].querySelector(".se-model-table-cell");
-                        event = new Event("click");
-                        cell.dispatchEvent(event);
-
-                        cell = rows[1].querySelector(".se-model-table-cell");
-                        event = new Event("click");
-                        event.ctrlKey = true;
-                        cell.dispatchEvent(event);
-
-                        cell = rows[2].querySelector(".se-model-table-cell");
-                        event = new Event("click");
-                        event.shiftKey = true;
-                        cell.dispatchEvent(event);
-
-                        // Check if css are applied properly
-                        expected = [false, true, true];
-                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(expected);
-                    });
-                });
-
-                describe("should allow click selections with shift and control keys pressed", function () {
-                    it("should allow first selection", function () {
-                        cell = rows[0].querySelector(".se-model-table-cell");
-                        event = new Event("click");
-                        event.shiftKey = true;
-                        event.ctrlKey = true;
-                        cell.dispatchEvent(event);
-
-                        // Check if css are applied properly
-                        expected = [true, false, false];
-                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(expected);
-                    });
-
-                    it("should allow range selection", function () {
-                        cell = rows[0].querySelector(".se-model-table-cell");
-                        event = new Event("click");
-                        cell.dispatchEvent(event);
-
-                        cell = rows[2].querySelector(".se-model-table-cell");
-                        event = new Event("click");
-                        event.shiftKey = true;
-                        event.ctrlKey = true;
-                        cell.dispatchEvent(event);
-
-                        // Check if css are applied properly
-                        expected = [true, true, true];
-                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(expected);
-                    });
-
-                    it("should not overwrite previous selection", function () {
-                        cell = rows[0].querySelector(".se-model-table-cell");
-                        event = new Event("click");
-                        cell.dispatchEvent(event);
-
-                        cell = rows[1].querySelector(".se-model-table-cell");
-                        event = new Event("click");
-                        event.ctrlKey = true;
-                        cell.dispatchEvent(event);
-
-                        cell = rows[2].querySelector(".se-model-table-cell");
-                        event = new Event("click");
-                        event.shiftKey = true;
-                        event.ctrlKey = true;
-                        cell.dispatchEvent(event);
-
-                        // Check if css are applied properly
-                        expected = [true, true, true];
-                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
-                        expect(observed).toEqual(expected);
-                    });
-                });
-
-                it("should deselect rows when no row is clicked", function () {
+                it("should allow multiple selection", function () {
                     cell = rows[0].querySelector(".se-model-table-cell");
-                    event = new Event("click");
+                    event = new MouseEvent("click");
                     cell.dispatchEvent(event);
 
                     cell = rows[2].querySelector(".se-model-table-cell");
-                    event = new Event("click");
-                    event.shiftKey = true;
+                    event = new MouseEvent("click", {ctrlKey: true});
                     cell.dispatchEvent(event);
 
-
-                    expected = [true, true, true];
+                    // Check if css are applied properly
+                    expected = [true, false, true];
                     observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
                     expect(observed).toEqual(expected);
+                });
 
-                    table.wrapperElement.click();
+                it("should allow diselect selected rows", function () {
+                    cell = rows[0].querySelector(".se-model-table-cell");
+                    event = new MouseEvent("click");
+                    cell.dispatchEvent(event);
+
+                    event = new MouseEvent("click", {ctrlKey: true});
+                    cell.dispatchEvent(event);
 
                     // Check if css are applied properly
                     expected = [false, false, false];
                     observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
                     expect(observed).toEqual(expected);
-
                 });
             });
+
+            describe("should allow click selections with shift key pressed", function () {
+                it("should allow first selection", function () {
+                    cell = rows[0].querySelector(".se-model-table-cell");
+                    event = new MouseEvent("click", {shiftKey: true});
+                    cell.dispatchEvent(event);
+
+                    // Check if css are applied properly
+                    expected = [true, false, false];
+                    observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                    expect(observed).toEqual(expected);
+                });
+
+                it("should allow range selection", function () {
+                    cell = rows[0].querySelector(".se-model-table-cell");
+                    event = new MouseEvent("click");
+                    cell.dispatchEvent(event);
+
+                    cell = rows[2].querySelector(".se-model-table-cell");
+                    event = new MouseEvent("click", {shiftKey: true});
+                    cell.dispatchEvent(event);
+
+                    // Check if css are applied properly
+                    expected = [true, true, true];
+                    observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                    expect(observed).toEqual(expected);
+                });
+
+                it("should overwrite previous selection", function () {
+                    cell = rows[0].querySelector(".se-model-table-cell");
+                    event = new MouseEvent("click");
+                    cell.dispatchEvent(event);
+
+                    cell = rows[1].querySelector(".se-model-table-cell");
+                    event = new MouseEvent("click", {ctrlKey: true});
+                    cell.dispatchEvent(event);
+
+                    cell = rows[2].querySelector(".se-model-table-cell");
+                    event = new MouseEvent("click", {shiftKey: true});
+                    cell.dispatchEvent(event);
+
+                    // Check if css are applied properly
+                    expected = [false, true, true];
+                    observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                    expect(observed).toEqual(expected);
+                });
+            });
+
+            describe("should allow click selections with shift and control keys pressed", function () {
+                it("should allow first selection", function () {
+                    cell = rows[0].querySelector(".se-model-table-cell");
+                    event = new MouseEvent("click", {shiftKey: true, ctrlKey: true});
+                    cell.dispatchEvent(event);
+
+                    // Check if css are applied properly
+                    expected = [true, false, false];
+                    observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                    expect(observed).toEqual(expected);
+                });
+
+                it("should allow range selection", function () {
+                    cell = rows[0].querySelector(".se-model-table-cell");
+                    event = new MouseEvent("click");
+                    cell.dispatchEvent(event);
+
+                    cell = rows[2].querySelector(".se-model-table-cell");
+                    event = new MouseEvent("click", {shiftKey: true, ctrlKey: true});
+                    cell.dispatchEvent(event);
+
+                    // Check if css are applied properly
+                    expected = [true, true, true];
+                    observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                    expect(observed).toEqual(expected);
+                });
+
+                it("should not overwrite previous selection", function () {
+                    cell = rows[0].querySelector(".se-model-table-cell");
+                    event = new MouseEvent("click");
+                    cell.dispatchEvent(event);
+
+                    cell = rows[1].querySelector(".se-model-table-cell");
+                    event = new MouseEvent("click", {ctrlKey: true});
+                    cell.dispatchEvent(event);
+
+                    cell = rows[2].querySelector(".se-model-table-cell");
+                    event = new MouseEvent("click", {shiftKey: true, ctrlKey: true});
+                    cell.dispatchEvent(event);
+
+                    // Check if css are applied properly
+                    expected = [true, true, true];
+                    observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                    expect(observed).toEqual(expected);
+                });
+            });
+
+            it("should deselect rows when no row is clicked", function () {
+                cell = rows[0].querySelector(".se-model-table-cell");
+                event = new MouseEvent("click");
+                cell.dispatchEvent(event);
+
+                cell = rows[2].querySelector(".se-model-table-cell");
+                event = new MouseEvent("click", {shiftKey: true});
+                cell.dispatchEvent(event);
+
+
+                expected = [true, true, true];
+                observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                expect(observed).toEqual(expected);
+
+                table.wrapperElement.click();
+
+                // Check if css are applied properly
+                expected = [false, false, false];
+                observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                expect(observed).toEqual(expected);
+
+            });
+
         });
 
 
@@ -712,31 +724,56 @@
             expect(cell).toBe(null);
         });
 
-        it("Destroy model table", function () {
-            var cell;
-            var columns = [
-                {field: "test", "label": "TestName", sortable: false, type: "number"}
-            ];
-            // Default options
-            var options = {};
-            // Create the table
-            table = new StyledElements.ModelTable(columns, options);
+        describe("destroy()", function () {
 
-            // Create and push the data
-            var data = [
-                {test: "hello world"}
-            ];
-            table.source.changeElements(data);
+            it("Destroy empty model table", function () {
+                var columns = [
+                    {field: "test", "label": "TestName", sortable: false, type: "number"}
+                ];
+                // Default options
+                var options = {};
+                // Create the table
+                table = new StyledElements.ModelTable(columns, options);
 
-            cell = table.wrapperElement.querySelector(".se-model-table-row .se-model-table-cell:first-child");
-            expect(cell.innerHTML).toBe("hello world");
+                expect(table.destroy()).toBe(table);
+            });
 
-            // Wipe the data
-            table.destroy();
+            it("Destroy model table with data", function () {
+                //
+                // Preparation
+                //
+                var cell;
+                var columns = [
+                    {field: "test", "label": "TestName", sortable: true, type: "number"}
+                ];
+                // Default options
+                var options = {};
+                // Create the table
+                table = new StyledElements.ModelTable(columns, options);
 
-            cell = table.wrapperElement.querySelector(".se-model-table-row .se-model-table-cell:first-child");
-            expect(cell).toBe(null);
+                // Create and push the data
+                var data = [
+                    {test: "hello world"}
+                ];
+                table.source.changeElements(data);
+
+                cell = table.wrapperElement.querySelector(".se-model-table-row .se-model-table-cell:first-child");
+                expect(cell.innerHTML).toBe("hello world");
+
+                //
+                // Action
+                //
+                expect(table.destroy()).toBe(table);
+
+                //
+                // Validation
+                //
+                cell = table.wrapperElement.querySelector(".se-model-table-row .se-model-table-cell:first-child");
+                expect(cell).toBe(null);
+            });
+
         });
+
     });
 
 })();

--- a/src/js_tests/styledelements/ModelTableSpec.js
+++ b/src/js_tests/styledelements/ModelTableSpec.js
@@ -358,6 +358,7 @@
                     {id: 2, test: "other world"}
                 ];
                 table.source.changeElements(data);
+                rows = table.wrapperElement.querySelectorAll(".se-model-table-row");
             });
 
             it("should allow simple selections", function () {
@@ -366,7 +367,6 @@
 
                 // Check if css are applied properly
                 expected = [false, true, false];
-                rows = table.wrapperElement.querySelectorAll(".se-model-table-row");
                 observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
 
                 expect(observed).toEqual(expected);
@@ -378,7 +378,6 @@
 
                 // Check if css are applied properly
                 expected = [false, true, true];
-                rows = table.wrapperElement.querySelectorAll(".se-model-table-row");
                 observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
 
                 expect(observed).toEqual(expected);
@@ -391,7 +390,6 @@
 
                 // Check if css are applied properly
                 expected = [false, false, false];
-                rows = table.wrapperElement.querySelectorAll(".se-model-table-row");
                 observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
                 expect(observed).toEqual(expected);
             });
@@ -402,12 +400,175 @@
 
                 // Check if css are applied properly
                 expected = [false, false, false];
-                rows = table.wrapperElement.querySelectorAll(".se-model-table-row");
                 observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
                 expect(observed).toEqual(expected);
             });
 
+            describe("Should handle mouse to select", function () {
+                var cell, event;
+
+                it("should allow click selections without modifiers", function () {
+                    cell = rows[0].querySelector(".se-model-table-cell");
+                    event = new Event("click");
+                    cell.dispatchEvent(event);
+
+                    // Check if css are applied properly
+                    expected = [true, false, false];
+                    observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                    expect(observed).toEqual(observed);
+                });
+
+                describe("should allow click selections with control key pressed", function () {
+                    it("should allow first selection", function () {
+                        cell = rows[0].querySelector(".se-model-table-cell");
+                        event = new Event("click");
+                        event.ctrlKey = true;
+                        cell.dispatchEvent(event);
+
+                        // Check if css are applied properly
+                        expected = [true, false, false];
+                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                        expect(observed).toEqual(observed);
+                    });
+
+                    it("should allow multiple selection", function () {
+                        cell = rows[0].querySelector(".se-model-table-cell");
+                        event = new Event("click");
+                        cell.dispatchEvent(event);
+
+                        cell = rows[2].querySelector(".se-model-table-cell");
+                        event = new Event("click");
+                        event.ctrlKey = true;
+                        cell.dispatchEvent(event);
+
+                        // Check if css are applied properly
+                        expected = [true, false, true];
+                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                        expect(observed).toEqual(observed);
+                    });
+
+                    it("should allow diselect selected rows", function () {
+                        cell = rows[0].querySelector(".se-model-table-cell");
+                        event = new Event("click");
+                        cell.dispatchEvent(event);
+
+                        event = new Event("click");
+                        event.ctrlKey = true;
+                        cell.dispatchEvent(event);
+
+                        // Check if css are applied properly
+                        expected = [false, false, false];
+                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                        expect(observed).toEqual(observed);
+                    });
+                });
+
+                describe("should allow click selections with shift key pressed", function () {
+                    it("should allow first selection", function () {
+                        cell = rows[0].querySelector(".se-model-table-cell");
+                        event = new Event("click");
+                        event.shiftKey = true;
+                        cell.dispatchEvent(event);
+
+                        // Check if css are applied properly
+                        expected = [true, false, false];
+                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                        expect(observed).toEqual(observed);
+                    });
+
+                    it("should allow range selection", function () {
+                        cell = rows[0].querySelector(".se-model-table-cell");
+                        event = new Event("click");
+                        cell.dispatchEvent(event);
+
+                        cell = rows[2].querySelector(".se-model-table-cell");
+                        event = new Event("click");
+                        event.shiftKey = true;
+                        cell.dispatchEvent(event);
+
+                        // Check if css are applied properly
+                        expected = [true, true, true];
+                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                        expect(observed).toEqual(observed);
+                    });
+
+                    it("should overwrite previous selection", function () {
+                        cell = rows[0].querySelector(".se-model-table-cell");
+                        event = new Event("click");
+                        cell.dispatchEvent(event);
+
+                        cell = rows[1].querySelector(".se-model-table-cell");
+                        event = new Event("click");
+                        event.ctrlKey = true;
+                        cell.dispatchEvent(event);
+
+                        cell = rows[2].querySelector(".se-model-table-cell");
+                        event = new Event("click");
+                        event.shiftKey = true;
+                        cell.dispatchEvent(event);
+
+                        // Check if css are applied properly
+                        expected = [false, true, true];
+                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                        expect(observed).toEqual(observed);
+                    });
+                });
+
+                describe("should allow click selections with shift and control keys pressed", function () {
+                    it("should allow first selection", function () {
+                        cell = rows[0].querySelector(".se-model-table-cell");
+                        event = new Event("click");
+                        event.shiftKey = true;
+                        event.ctrlKey = true;
+                        cell.dispatchEvent(event);
+
+                        // Check if css are applied properly
+                        expected = [true, false, false];
+                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                        expect(observed).toEqual(observed);
+                    });
+
+                    it("should allow range selection", function () {
+                        cell = rows[0].querySelector(".se-model-table-cell");
+                        event = new Event("click");
+                        cell.dispatchEvent(event);
+
+                        cell = rows[2].querySelector(".se-model-table-cell");
+                        event = new Event("click");
+                        event.shiftKey = true;
+                        event.ctrlKey = true;
+                        cell.dispatchEvent(event);
+
+                        // Check if css are applied properly
+                        expected = [true, true, true];
+                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                        expect(observed).toEqual(observed);
+                    });
+
+                    it("should not overwrite previous selection", function () {
+                        cell = rows[0].querySelector(".se-model-table-cell");
+                        event = new Event("click");
+                        cell.dispatchEvent(event);
+
+                        cell = rows[1].querySelector(".se-model-table-cell");
+                        event = new Event("click");
+                        event.ctrlKey = true;
+                        cell.dispatchEvent(event);
+
+                        cell = rows[2].querySelector(".se-model-table-cell");
+                        event = new Event("click");
+                        event.shiftKey = true;
+                        cell.dispatchEvent(event);
+
+                        // Check if css are applied properly
+                        expected = [true, true, true];
+                        observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                        expect(observed).toEqual(observed);
+                    });
+                });
+            });
         });
+
 
         it("Should handle row's content builder", function () {
             var rows;

--- a/src/js_tests/styledelements/ModelTableSpec.js
+++ b/src/js_tests/styledelements/ModelTableSpec.js
@@ -349,7 +349,7 @@
                 ];
 
                 // Create a new table
-                table = new StyledElements.ModelTable(columns, {id: 'id', allowMultipleSelect: true});
+                table = new StyledElements.ModelTable(columns, {id: 'id', selectionType: "multiple"});
 
                 // Create and push the data
                 var data = [
@@ -361,7 +361,26 @@
                 rows = table.wrapperElement.querySelectorAll(".se-model-table-row");
             });
 
-            it("should allow simple selections", function () {
+            it("should throw an error if selection is disabled", function () {
+                var columns = [
+                    {field: "id", type: "number"}
+                ];
+
+                // Create a new table
+                table = new StyledElements.ModelTable(columns, {id: 'id', selectionType: "ignore"});
+
+                // Create and push the data
+                var data = [
+                    {id: 0}
+                ];
+                table.source.changeElements(data);
+                rows = table.wrapperElement.querySelectorAll(".se-model-table-row");
+
+                expect(function () {table.select(0);}).toThrow(new Error("Selection is disabled"));
+
+            });
+
+            it("should allow single selections", function () {
                 expect(table.select(1)).toBe(table);
                 expect(table.selection).toEqual([1]);
 
@@ -370,6 +389,25 @@
                 observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
 
                 expect(observed).toEqual(expected);
+            });
+
+            it("should throw an error if selection is simple and tries to select more than one row", function () {
+                var columns = [
+                    {field: "id", type: "number"}
+                ];
+
+                // Create a new table
+                table = new StyledElements.ModelTable(columns, {id: 'id', selectionType: "single"});
+
+                // Create and push the data
+                var data = [
+                    {id: 0},
+                    {id: 1}
+                ];
+                table.source.changeElements(data);
+                rows = table.wrapperElement.querySelectorAll(".se-model-table-row");
+
+                expect(function () {table.select([0, 1]);}).toThrow(new Error("Selection is set to \"single\" but tried to select 2 rows."));
             });
 
             it("should allow multiple selections", function () {
@@ -419,6 +457,7 @@
                 });
 
                 describe("should allow click selections with control key pressed", function () {
+
                     it("should allow first selection", function () {
                         cell = rows[0].querySelector(".se-model-table-cell");
                         event = new Event("click");

--- a/src/js_tests/styledelements/ModelTableSpec.js
+++ b/src/js_tests/styledelements/ModelTableSpec.js
@@ -566,6 +566,30 @@
                         expect(observed).toEqual(observed);
                     });
                 });
+
+                it("should deselect rows when no row is clicked", function () {
+                    cell = rows[0].querySelector(".se-model-table-cell");
+                    event = new Event("click");
+                    cell.dispatchEvent(event);
+
+                    cell = rows[2].querySelector(".se-model-table-cell");
+                    event = new Event("click");
+                    event.shiftKey = true;
+                    cell.dispatchEvent(event);
+
+
+                    expected = [true, true, true];
+                    observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                    expect(observed).toEqual(observed);
+
+                    table.wrapperElement.click();
+
+                    // Check if css are applied properly
+                    expected = [false, false, false];
+                    observed = Array.prototype.map.call(rows, function (row) {return row.classList.contains("highlight");});
+                    expect(observed).toEqual(observed);
+
+                });
             });
         });
 

--- a/src/wirecloud/commons/static/js/StyledElements/ModelTable.js
+++ b/src/wirecloud/commons/static/js/StyledElements/ModelTable.js
@@ -288,6 +288,16 @@
 
         this.wrapperElement = priv.layout.wrapperElement;
 
+        // Deselect rows if clicked no row is clicked
+        this.wrapperElement.addEventListener("click", function (evt) {
+            // Only deselect if no modifier key is pressed
+            if (!evt.shiftKey && !evt.ctrlKey) {
+                this.select([]);
+                this.trigger("select", []);
+            }
+
+        }.bind(this));
+
         /*
          * Header
          */
@@ -492,6 +502,9 @@
 
     // Row clicked callback
     var rowCallback = function rowCallback(evt) {
+        // Stop propagation so wrapperElement's click is not called
+        evt.stopPropagation();
+
         changeSelection.call(this.table, this.item, evt, this.index);
         this.table.events.click.dispatch(this.item, evt);
     };

--- a/src/wirecloud/commons/static/js/StyledElements/ModelTable.js
+++ b/src/wirecloud/commons/static/js/StyledElements/ModelTable.js
@@ -19,8 +19,7 @@
  *
  */
 
-/* globals moment, StyledElements */
-
+/* globals moment, StyledElements, WeakMap */
 
 (function (utils) {
 
@@ -218,6 +217,10 @@
 
         StyledElements.StyledElement.call(this, ['click', 'select']);
 
+        // Initialize private variables
+        var priv = {};
+        privates.set(this, priv);
+
         priv.selection = [];
         var source;
         if (options.source != null) {
@@ -293,7 +296,8 @@
             // Only deselect if no modifier key is pressed
             if (!evt.shiftKey && !evt.ctrlKey) {
                 this.select([]);
-                this.trigger("select", []);
+                // this.trigger("select", []);
+                this.events.select.dispatch([]);
             }
 
         }.bind(this));
@@ -327,6 +331,7 @@
         this.source.addEventListener('requestEnd', onRequestEnd.bind(this));
 
         if (this.source.options.pageSize !== 0) {
+
             priv.paginationInterface = new StyledElements.PaginationInterface(this.source);
             priv.statusBar.appendChild(priv.paginationInterface);
         }
@@ -635,7 +640,6 @@
     };
 
     var privates = new WeakMap();
-
 
     StyledElements.ModelTable = ModelTable;
 

--- a/src/wirecloud/commons/static/js/StyledElements/ModelTable.js
+++ b/src/wirecloud/commons/static/js/StyledElements/ModelTable.js
@@ -202,7 +202,7 @@
             'initialSortColumn': -1,
             'pageSize': 5,
             'emptyMessage': utils.gettext('No data available'),
-            'selectionType': "ignore"
+            'selectionType': "none"
         };
 
         options = utils.merge(defaultOptions, options);
@@ -270,7 +270,7 @@
                         throw new TypeError();
                     }
                     if (priv.selectionType === "single" && value.length > 1) {
-                        throw new Error("Selection is set to \"single\" but tried to select " + value.length + " rows.");
+                        throw new Error("Selection is set to \"single\" but tried to select more than one rows.");
                     }
                     // Unhighlihgt previous selection
                     priv.selection.forEach(function (id) {
@@ -393,15 +393,18 @@
     ModelTable.prototype.Tooltip = StyledElements.Tooltip;
 
     /**
-     * Changes current selection
+     * Changes current selection. Removes the selection when no passing any parameter
+     *
      * @since 0.6.3
      *
-     * @param {String|String[]} [id]
+     * @param {String|String[]} [selection]
+     * @returns {StyledElements.ModelTable}
+     *     The instance on which the member is called.
      */
-    ModelTable.prototype.select = function select(id) {
-        if (id != null) {
+    ModelTable.prototype.select = function select(selection) {
+        if (selection != null) {
             // Update current selection
-            this.selection = Array.isArray(id) ? id : [id];
+            this.selection = Array.isArray(selection) ? selection : [selection];
         } else {
             this.selection = [];
         }
@@ -660,6 +663,8 @@
         }
 
         this.source.destroy();
+
+        return this;
     };
 
     var privates = new WeakMap();

--- a/src/wirecloud/commons/static/js/StyledElements/ModelTable.js
+++ b/src/wirecloud/commons/static/js/StyledElements/ModelTable.js
@@ -201,8 +201,10 @@
         defaultOptions = {
             'initialSortColumn': -1,
             'pageSize': 5,
-            'emptyMessage': utils.gettext('No data available')
+            'emptyMessage': utils.gettext('No data available'),
+            'allowMultipleSelect': false
         };
+
         options = utils.merge(defaultOptions, options);
 
         if (options.class != null) {
@@ -222,6 +224,7 @@
         privates.set(this, priv);
 
         priv.selection = [];
+        priv.allowMultipleSelect = options.allowMultipleSelect;
         var source;
         if (options.source != null) {
             source = options.source;
@@ -521,7 +524,7 @@
         var selected, data, lastSelectedIndex, lower, upper, j;
         var id = priv.extractIdFunc(row);
 
-        if (event.ctrlKey && event.shiftKey) {
+        if (priv.allowMultipleSelect && event.ctrlKey && event.shiftKey) {
             // Control + shift behaviour
             data = this.source.getCurrentPage();
             lastSelectedIndex = data.indexOf(priv.lastSelected);
@@ -543,7 +546,7 @@
                 event.target.ownerDocument.defaultView.getSelection().removeAllRanges();
             }
 
-        } else if (event.shiftKey) {
+        } else if (priv.allowMultipleSelect && event.shiftKey) {
             // Shift behaviour
             data = this.source.getCurrentPage();
             lastSelectedIndex = data.indexOf(priv.lastSelected);
@@ -563,7 +566,7 @@
                 event.target.ownerDocument.defaultView.getSelection().removeAllRanges();
             }
 
-        } else if (event.ctrlKey) {
+        } else if (priv.allowMultipleSelect && event.ctrlKey) {
             // control behaviour
             priv.lastSelected = row;
             selected = this.selection.slice();

--- a/src/wirecloud/commons/static/js/StyledElements/ModelTable.js
+++ b/src/wirecloud/commons/static/js/StyledElements/ModelTable.js
@@ -522,6 +522,7 @@
                     aux.push(priv.extractIdFunc(data[j]));
                 }
                 selected = selected.concat(aux);
+                event.target.ownerDocument.defaultView.getSelection().removeAllRanges();
             }
 
         } else if (event.shiftKey) {
@@ -541,10 +542,8 @@
                 for (j = lower; j <= upper; j++) {
                     selected.push(priv.extractIdFunc(data[j]));
                 }
+                event.target.ownerDocument.defaultView.getSelection().removeAllRanges();
             }
-            // var idoc = this.wrapperElement.contentDocument || this.wrapperElement.contentWindow.document; // ie compatibility
-            // idoc.getSelection().removeAllRanges();
-            // window.getSelection().removeAllRanges();
 
         } else if (event.ctrlKey) {
             // control behaviour


### PR DESCRIPTION
**This is based upon #207**

Refactored row selection to be done by the ModelTable instead of being done by the DataViewer widget.

Allows selection of multiple rows using the control and alt key modifiers to choose the selection behaviour.

Three types of selection behaviour: 
-  Ignored: Selection is disabled.
-  Single: Only one row can be selected.
-  Multiple rows can be selected.

Added an event to send the current selection on change.

**Requires the DataViewer widget changes done by [wirecloud/data-viwer-widget#3](https://github.com/Wirecloud/data-table-viewer-widget/pull/3) to work with it.**
