### PR TITLE
Secure preferences improvements

### DIFF
--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -35,6 +35,7 @@ step, as they will be installed throughout the documentation:**
     - pyScss 1.3.4+
     - Pygments
     - pillow
+    - jsonpatch
 
 All these dependencies are available for Linux, Mac OS and Windows, so WireCloud
 should work on any of these operating systems. However, it is better to use

--- a/docs/restapi/applicationmashup.apib
+++ b/docs/restapi/applicationmashup.apib
@@ -1,8 +1,8 @@
 FORMAT: 1A
 HOST: https://mashup.lab.fiware.org/
 TITLE: FIWARE Application Mashup RESTful v2.1 Specification
-DATE: 26th August 2016
-VERSION: v2.1
+DATE: 25th January 2017
+VERSION: v2.2
 PREVIOUS_VERSION: v2
 APIARY_PROJECT: fiwareapplicationmashup
 SPEC_URL: http://wirecloud.github.io/wirecloud/restapi/
@@ -43,7 +43,7 @@ to [wirecloud@conwet.com](mailto:wirecloud@conwet.com)
 
 ## Copyright
 
-Copyright © 2012-2016 by Universidad Politécnica de Madrid
+Copyright © 2012-2017 by Universidad Politécnica de Madrid
 
 ## License
 
@@ -115,10 +115,8 @@ Where possible, this API strives to use appropriate HTTP verbs for each action.
 | `POST`    | Used for creating resources.                                         |
 | `PUT`     | Used for replacing resources.                                        |
 | `DELETE`  | Used for deleting resources.                                         |
-
-<!--
 | `PATCH`   | Used for updating resources with partial JSON data (using the `application/json-patch+json` mimetype). For instance, a Workspace resource has several attributes. A `PATCH` request may accept one or more of the attributes to update the resource. `PATCH` is a relatively new and uncommon HTTP verb, so resource endpoints also accept `POST` requests. |
--->
+
 
 Any API endpoint supporting the `GET` method must also support the `HEAD` method.
 
@@ -691,6 +689,67 @@ Workspace attributes that can be modified:
 
 + Response 204
 
+
+### Patch workspace wiring configuration [PATCH /api/workspace/{workspace_id}/wiring]
+
+- `version` (string): Format version used in this wiring configuration. At present, the only available version is "2.0".
+- `operators` (object): Description of the operators used in this wiring description.
+- `connections` (array): Connections stablished between widgets and operators.
+- `visualdescription` (object): Visual description. Used for displaying this wiring configuration in the user interface.
+
+**Used status codes**: 204, 400, 401, 403, 404, 413, 422
+
+> *new in WireCloud 1.1 / FIWARE Application Mashup RESTful Specification v2.2*
+
++ Parameters
+
+    + workspace_id: 81 (number) - ID of the workspace
+
++ Request Replace a preference and add an operator (application/json-patch+json)
+
+    + Headers
+
+            Accept: application/json-patch+json
+            Authorization: Bearer YOUR_OAUTH2_TOKEN
+
+    + Body
+            [
+                {
+                    "op": "replace",
+                    "path": "/operators/1/preferences/preferenceName/value",
+                    "value": 'newPreferenceValue',
+                },
+                {
+                    "op": "add",
+                    "path": "/operators/0/",
+                    "value": {
+                        "name": "UPM/Operator/0.1",
+                        "id": "0"
+                    },
+                }
+            ]
+
++ Response 204
+
++ Request Remove operator
+
+    + Headers
+
+            Accept: application/json-patch+json
+            Authorization: Bearer YOUR_OAUTH2_TOKEN
+
+    + Body
+            [
+                {
+                    "op": "remove",
+                    "path": "/operators/1",
+                }
+            ]
+
++ Response 204
+
+
+
 ### Update workspace wiring configuration [PUT /api/workspace/{workspace_id}/wiring]
 
 - `version` (string): Format version used in this wiring configuration. At present, the only available version is "2.0".
@@ -816,7 +875,7 @@ Returned fields:
 
 **Used status codes**: 200, 401, 403, 404, 406, 413, 415, 422
 
-> *new in WireCloud 1.0*
+> *new in WireCloud 1.0 / FIWARE Application Mashup RESTful Specification v2.1*
 
 + Request
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -150,6 +150,7 @@ setup(
         'pyScss>=1.3.4,<2.0',
         'Pygments',
         'pillow',
+        'jsonpatch',
     ),
     extras_require={
         ":python_version < '3.2'": ('futures>=2.1.3',),

--- a/src/wirecloud/commons/baseviews/resource.py
+++ b/src/wirecloud/commons/baseviews/resource.py
@@ -31,6 +31,7 @@ METHOD_MAPPING = {
     'PUT': 'update',
     'DELETE': 'delete',
     'HEAD': 'head',
+    'PATCH': 'patch',
 }
 
 

--- a/src/wirecloud/commons/fixtures/user_with_workspaces.json
+++ b/src/wirecloud/commons/fixtures/user_with_workspaces.json
@@ -281,6 +281,16 @@
         }
     },
     {
+        "model": "platform.Workspace",
+        "pk": 202,
+        "fields": {
+            "name": "workspaceSecure",
+            "public": false,
+            "creator": "4",
+            "wiringStatus": "{\"operators\": {\"1\": {\"name\": \"Wirecloud/TestOperatorSecure/1.0\", \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": \"\"}, \"username\": {\"secure\": false, \"readonly\": true, \"hidden\": false, \"value\": \"username\"}}}, \"2\": {\"name\": \"Wirecloud/TestOperatorSecure/1.0\", \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": \"test_password\"}, \"username\": {\"secure\": false, \"readonly\": true, \"hidden\": false, \"value\": \"test_username\"}}}}, \"connections\": []}"
+        }
+    },
+    {
         "pk": 2,
         "model": "platform.userworkspace",
         "fields": {

--- a/src/wirecloud/platform/core/plugins.py
+++ b/src/wirecloud/platform/core/plugins.py
@@ -604,7 +604,7 @@ class WirecloudCorePlugin(WirecloudPlugin):
             {'id': 'WORKSPACE_RESOURCE_COLLECTION', 'url': build_url_template('wirecloud.workspace_resource_collection', ['workspace_id'])},
             {'id': 'WORKSPACE_VIEW', 'url': build_url_template('wirecloud.workspace_view', ['owner', 'name'])},
 
-            {'id': 'OPERATOR_PREFERENCES', 'url': build_url_template('wirecloud.workspace_operatorpref', ['workspace_id', 'operator_id'])},
+            {'id': 'OPERATOR_PREFERENCES', 'url': build_url_template('wirecloud.workspace_operator_preferences', ['workspace_id', 'operator_id'])},
         )
 
         from django.conf import settings

--- a/src/wirecloud/platform/core/plugins.py
+++ b/src/wirecloud/platform/core/plugins.py
@@ -603,6 +603,8 @@ class WirecloudCorePlugin(WirecloudPlugin):
             {'id': 'WORKSPACE_PUBLISH', 'url': build_url_template('wirecloud.workspace_publish', ['workspace_id'])},
             {'id': 'WORKSPACE_RESOURCE_COLLECTION', 'url': build_url_template('wirecloud.workspace_resource_collection', ['workspace_id'])},
             {'id': 'WORKSPACE_VIEW', 'url': build_url_template('wirecloud.workspace_view', ['owner', 'name'])},
+
+            {'id': 'OPERATOR_PREFERENCES', 'url': build_url_template('wirecloud.workspace_operatorpref', ['workspace_id', 'operator_id'])},
         )
 
         from django.conf import settings

--- a/src/wirecloud/platform/core/plugins.py
+++ b/src/wirecloud/platform/core/plugins.py
@@ -603,8 +603,6 @@ class WirecloudCorePlugin(WirecloudPlugin):
             {'id': 'WORKSPACE_PUBLISH', 'url': build_url_template('wirecloud.workspace_publish', ['workspace_id'])},
             {'id': 'WORKSPACE_RESOURCE_COLLECTION', 'url': build_url_template('wirecloud.workspace_resource_collection', ['workspace_id'])},
             {'id': 'WORKSPACE_VIEW', 'url': build_url_template('wirecloud.workspace_view', ['owner', 'name'])},
-
-            {'id': 'OPERATOR_PREFERENCES', 'url': build_url_template('wirecloud.workspace_operator_preferences', ['workspace_id', 'operator_id'])},
         )
 
         from django.conf import settings

--- a/src/wirecloud/platform/fixtures/test_data.json
+++ b/src/wirecloud/platform/fixtures/test_data.json
@@ -74,6 +74,16 @@
         }
     },
     {
+        "model": "platform.Workspace",
+        "pk": "202",
+        "fields": {
+            "name": "workspaceSecure",
+            "public": false,
+            "creator": "2",
+            "wiringStatus": "{\"operators\": {\"1\": {\"name\": \"Wirecloud/TestOperatorSecure/1.0\", \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": \"\"}, \"username\": {\"secure\": false, \"readonly\": false, \"hidden\": false, \"value\": \"username\"}}}, \"2\": {\"name\": \"Wirecloud/TestOperatorSecure/1.0\", \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": \"test_password\"}, \"username\": {\"secure\": false, \"readonly\": false, \"hidden\": false, \"value\": \"test_username\"}}}}, \"connections\": []}"
+        }
+    },
+    {
         "model": "platform.UserWorkspace",
         "pk": "1",
         "fields": {
@@ -82,11 +92,28 @@
         }
     },
     {
+        "model": "platform.UserWorkspace",
+        "pk": "2",
+        "fields": {
+            "user": "2",
+            "workspace": "202"
+        }
+    },
+    {
         "model": "platform.Tab",
         "pk": "1",
         "fields": {
             "workspace": "1",
             "name": "tab",
+            "visible": true
+        }
+    },
+    {
+        "model": "platform.Tab",
+        "pk": "2",
+        "fields": {
+            "workspace": "202",
+            "name": "tabSecure",
             "visible": true
         }
     },
@@ -111,6 +138,30 @@
             "name": "Test Widget 2",
             "positions": "{\"widget\":{\"minimized\":false,\"height\":24,\"width\":6,\"zIndex\":1,\"left\":5,\"top\":0,\"fulldragboard\":false},\"icon\":{\"top\":0,\"left\":0}}",
             "tab": "1",
+            "variables": "{\"password\": \"test_password\", \"username\": \"test_username\", \"prop\": \"test_data\"}"
+        }
+    },
+    {
+        "model": "platform.IWidget",
+        "pk": "3",
+        "fields": {
+            "widget": "1",
+            "widget_uri": "Test/Test Widget/1.0.0",
+            "name": "Secure Widget 1",
+            "positions": "{\"widget\":{\"minimized\":false,\"height\":24,\"width\":6,\"zIndex\":0,\"left\":0,\"top\":0,\"fulldragboard\":false},\"icon\":{\"top\":0,\"left\":0}}",
+            "tab": "2",
+            "variables": "{\"password\": \"\", \"username\": \"test_username\", \"prop\": \"test_data\"}"
+        }
+    },
+    {
+        "model": "platform.IWidget",
+        "pk": "4",
+        "fields": {
+            "widget": "1",
+            "widget_uri": "Test/Test Widget/1.0.0",
+            "name": "Secure Widget 2",
+            "positions": "{\"widget\":{\"minimized\":false,\"height\":24,\"width\":6,\"zIndex\":0,\"left\":0,\"top\":0,\"fulldragboard\":false},\"icon\":{\"top\":0,\"left\":0}}",
+            "tab": "2",
             "variables": "{\"password\": \"test_password\", \"username\": \"test_username\", \"prop\": \"test_data\"}"
         }
     },
@@ -142,6 +193,24 @@
             "vendor": "Wirecloud",
             "short_name": "TestOperator",
             "json_description": "{\"default_lang\": \"en\", \"vendor\": \"Wirecloud\", \"description\": \"Test operator description\", \"translations\": {}, \"smartphoneimage\": \"\", \"translation_index_usage\": {}, \"title\": \"TestOperator\", \"properties\": [], \"js_files\": [\"js/main.js\"], \"requirements\": [], \"preferences\": [{\"default\": \"\", \"name\": \"pref_with_val\", \"label\": \"Prefix\", \"type\": \"text\", \"description\": \"\"},{\"default\": \"false\", \"name\": \"readonly_pref\", \"label\": \"Throw exceptions\", \"type\": \"text\", \"description\": \"Raise exception on event arrival\"},{\"default\": \"false\", \"name\": \"hidden_pref\", \"label\": \"Run logging tests\", \"type\": \"boolean\", \"description\": \"Run logging support tests on change to true\"}, {\"default\": \"default_value\", \"name\": \"empty_pref\", \"label\": \"Empty\", \"type\": \"text\", \"description\": \"\"}], \"authors\": \"admin\", \"wiring\": {\"inputs\": [{\"friendcode\": \"test_friend_code\", \"actionlabel\": \"\", \"name\": \"input\", \"label\": \"input\", \"type\": \"text\", \"description\": \"\"}], \"outputs\": [{\"friendcode\": \"test_friend_code\", \"description\": \"\", \"type\": \"text\", \"name\": \"output\", \"label\": \"output\"}]}, \"name\": \"TestOperator\", \"image\": \"images/catalogue.png\", \"version\": \"1.0\", \"context\": [], \"widget_height\": \"\", \"email\": \"test@example.com\", \"type\": \"operator\", \"widget_width\": \"\", \"doc\": \"doc/index.html\"}",
+            "creator": 2,
+            "creation_date": "2011-05-13T11:24:03Z",
+            "version": "1.0",
+            "type": 2,
+            "public": false,
+            "users": [2]
+        }
+    },
+    {
+        "pk": 3,
+        "model": "catalogue.CatalogueResource",
+        "fields": {
+            "groups": [],
+            "template_uri": "Wirecloud_TestOperatorSecure_1.0.wgt",
+            "popularity": "0",
+            "vendor": "Wirecloud",
+            "short_name": "TestOperatorSecure",
+            "json_description": "{\"default_lang\": \"en\", \"vendor\": \"Wirecloud\", \"description\": \"Test operator description\", \"translations\": {}, \"smartphoneimage\": \"\", \"translation_index_usage\": {}, \"title\": \"TestOperator\", \"properties\": [], \"js_files\": [\"js/main.js\"], \"requirements\": [], \"preferences\": [{\"default\": \"\", \"name\": \"pref_secure\", \"secure\": true, \"label\": \"Prefix\", \"type\": \"text\", \"description\": \"\"}, {\"default\": \"\", \"name\": \"username\", \"secure\": false, \"label\": \"Prefix\", \"type\": \"text\", \"description\": \"\"}], \"authors\": \"admin\", \"wiring\": {\"inputs\": [{\"friendcode\": \"test_friend_code\", \"actionlabel\": \"\", \"name\": \"input\", \"label\": \"input\", \"type\": \"text\", \"description\": \"\"}], \"outputs\": [{\"friendcode\": \"test_friend_code\", \"description\": \"\", \"type\": \"text\", \"name\": \"output\", \"label\": \"output\"}]}, \"name\": \"TestOperator\", \"image\": \"images/catalogue.png\", \"version\": \"1.0\", \"context\": [], \"widget_height\": \"\", \"email\": \"test@example.com\", \"type\": \"operator\", \"widget_width\": \"\", \"doc\": \"doc/index.html\"}",
             "creator": 2,
             "creation_date": "2011-05-13T11:24:03Z",
             "version": "1.0",

--- a/src/wirecloud/platform/static/js/WirecloudAPI/WirecloudAPICommon.js
+++ b/src/wirecloud/platform/static/js/WirecloudAPI/WirecloudAPICommon.js
@@ -38,6 +38,9 @@
     Object.defineProperty(window.MashupPlatform.http, 'makeRequest', {
         value: function makeRequest(url, options) {
             url = new platform.URL(url, window.location);
+            if (!options.requestHeaders) {
+                options.requestHeaders = {};
+            }
             options.requestHeaders["wirecloud-component-type"] = componentType;
             return Wirecloud.io.makeRequest(url, options);
         }

--- a/src/wirecloud/platform/static/js/WirecloudAPI/WirecloudAPICommon.js
+++ b/src/wirecloud/platform/static/js/WirecloudAPI/WirecloudAPICommon.js
@@ -42,6 +42,7 @@
                 options.requestHeaders = {};
             }
             options.requestHeaders["wirecloud-component-type"] = componentType;
+            options.requestHeaders["wirecloud-component-id"] = resource.id;
             return Wirecloud.io.makeRequest(url, options);
         }
     });

--- a/src/wirecloud/platform/static/js/WirecloudAPI/WirecloudAPICommon.js
+++ b/src/wirecloud/platform/static/js/WirecloudAPI/WirecloudAPICommon.js
@@ -29,6 +29,7 @@
     var platform = window.parent;
     var Wirecloud = platform.Wirecloud;
     var resource = MashupPlatform.priv.resource;
+    var componentType = resource instanceof Wirecloud.Widget ? "widget" : "operator";
     var guibuilder = new platform.StyledElements.GUIBuilder();
 
     // HTTP module
@@ -37,6 +38,7 @@
     Object.defineProperty(window.MashupPlatform.http, 'makeRequest', {
         value: function makeRequest(url, options) {
             url = new platform.URL(url, window.location);
+            options.requestHeaders["wirecloud-component-type"] = componentType;
             return Wirecloud.io.makeRequest(url, options);
         }
     });

--- a/src/wirecloud/platform/static/js/wirecloud/Widget/PreferencesWindowMenu.js
+++ b/src/wirecloud/platform/static/js/wirecloud/Widget/PreferencesWindowMenu.js
@@ -50,19 +50,20 @@
         }
 
         this.hide();
-
-        Wirecloud.io.makeRequest(Wirecloud.URLs.IWIDGET_PREFERENCES.evaluate({
-                workspace_id: this.widgetModel.tab.workspace.id,
-                tab_id: this.widgetModel.tab.id,
-                iwidget_id: this.widgetModel.id
-            }), {
-                method: 'POST',
-                contentType: 'application/json',
-                requestHeaders: {'Accept': 'application/json'},
-                postBody: JSON.stringify(new_values),
-                onSuccess: widgetCallback.call(this, new_values)
-            }
-        );
+        if (!this.widgetModel.volatile) {
+            Wirecloud.io.makeRequest(Wirecloud.URLs.IWIDGET_PREFERENCES.evaluate({
+                    workspace_id: this.widgetModel.tab.workspace.id,
+                    tab_id: this.widgetModel.tab.id,
+                    iwidget_id: this.widgetModel.id
+                }), {
+                    method: 'POST',
+                    contentType: 'application/json',
+                    requestHeaders: {'Accept': 'application/json'},
+                    postBody: JSON.stringify(new_values),
+                    onSuccess: widgetCallback.call(this, new_values)
+                }
+            );
+        }
     };
 
     // Notify preference changes to widget

--- a/src/wirecloud/platform/static/js/wirecloud/Widget/PreferencesWindowMenu.js
+++ b/src/wirecloud/platform/static/js/wirecloud/Widget/PreferencesWindowMenu.js
@@ -39,7 +39,7 @@
             newValue = new_values[varName];
 
             if (newValue !== oldValue) {
-                if (this.widgetModel.preferences[varName].meta.options.secure && this.widgetModel.preferences[varName].value !== "") {
+                if (this.widgetModel.preferences[varName].meta.options.secure && newValue !== "") {
                     this.widgetModel.preferences[varName].value = "********";
                 } else {
                     this.widgetModel.preferences[varName].value = newValue;

--- a/src/wirecloud/platform/static/js/wirecloud/Widget/PreferencesWindowMenu.js
+++ b/src/wirecloud/platform/static/js/wirecloud/Widget/PreferencesWindowMenu.js
@@ -32,14 +32,18 @@
     utils.inherit(PreferencesWindowMenu, Wirecloud.ui.WindowMenu);
 
     PreferencesWindowMenu.prototype._savePrefs = function _savePrefs(form, new_values) {
-        var oldValue, newValue, varName, details;
+        var oldValue, newValue, varName;
 
         for (varName in new_values) {
             oldValue = this.widgetModel.preferences[varName].value;
             newValue = new_values[varName];
 
             if (newValue !== oldValue) {
-                this.widgetModel.preferences[varName].value = newValue;
+                if (this.widgetModel.preferences[varName].meta.options.secure && this.widgetModel.preferences[varName].value !== "") {
+                    this.widgetModel.preferences[varName].value = "********";
+                } else {
+                    this.widgetModel.preferences[varName].value = newValue;
+                }
             } else {
                 delete new_values[varName];
             }
@@ -55,15 +59,25 @@
                 method: 'POST',
                 contentType: 'application/json',
                 requestHeaders: {'Accept': 'application/json'},
-                postBody: JSON.stringify(new_values)
+                postBody: JSON.stringify(new_values),
+                onSuccess: widgetCallback.call(this, new_values)
             }
         );
+    };
 
+    // Notify preference changes to widget
+    var widgetCallback = function widgetCallback(new_values) {
         if (typeof this.widgetModel.prefCallback === 'function') {
             try {
+                // Censor secure preferences
+                for (var varName in new_values) {
+                    if (this.widgetModel.preferences[varName].meta.options.secure && this.widgetModel.preferences[varName].value !== "") {
+                        new_values[varName] = "********";
+                    }
+                }
                 this.widgetModel.prefCallback(new_values);
             } catch (error) {
-                details = this.widgetModel.logManager.formatException(error);
+                var details = this.widgetModel.logManager.formatException(error);
                 this.widgetModel.logManager.log(utils.gettext('Exception catched while processing preference changes'), {details: details});
             }
         }

--- a/src/wirecloud/platform/static/js/wirecloud/Wiring.js
+++ b/src/wirecloud/platform/static/js/wirecloud/Wiring.js
@@ -182,12 +182,29 @@
                 volatile: false
             }, data);
 
+            var operator = create_operator.call(this, resource, data)
+
             if (data.volatile) {
-                return append_operator.call(this, create_operator.call(this, resource, data));
+                return append_operator.call(this, operator);
             }
 
+            var requestContent = [{
+                op: "add",
+                path: "/operators/" + operator.id,
+                value: operator,
+            }];
             return new Promise(function (resolve, reject) {
-                resolve(create_operator.call(this, resource, data));
+                Wirecloud.io.makeRequest(Wirecloud.URLs.WIRING_ENTRY.evaluate({
+                    workspace_id: this.workspace.id,
+                }), {
+                    method: 'PATCH',
+                    contentType: 'application/json-patch+json',
+                    requestHeaders: {'Accept': 'application/json'},
+                    postBody: JSON.stringify(requestContent),
+                    onSuccess: resolve(operator),
+                    onFailure: reject(operator)
+                }
+                );
             }.bind(this));
         },
 

--- a/src/wirecloud/platform/static/js/wirecloud/ui/OperatorPreferencesWindowMenu.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/OperatorPreferencesWindowMenu.js
@@ -36,7 +36,12 @@
 
         for (key in new_values) {
             if (this._current_ioperator.preferences[key].value !== new_values[key]) {
-                this._current_ioperator.preferences[key].value = new_values[key];
+
+                if (this._current_ioperator.preferences[key].meta.options.secure && new_values[key] !== "") {
+                    this._current_ioperator.preferences[key].value = "********";
+                } else {
+                    this._current_ioperator.preferences[key].value = new_values[key];
+                }
             } else {
                 delete new_values[key];
             }

--- a/src/wirecloud/platform/static/js/wirecloud/ui/OperatorPreferencesWindowMenu.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/OperatorPreferencesWindowMenu.js
@@ -75,6 +75,12 @@
     var operatorCallback = function operatorCallback(new_values) {
         if (typeof this._current_ioperator.prefCallback === 'function') {
             try {
+                // Censor secure preferences
+                for (var varName in new_values) {
+                    if (this._current_ioperator.preferences[varName].meta.options.secure && this._current_ioperator.preferences[varName].value !== "") {
+                        new_values[varName] = "********";
+                    }
+                }
                 this._current_ioperator.prefCallback(new_values);
             } catch (error) {
                 var details = this._current_ioperator.logManager.formatException(error);
@@ -82,6 +88,7 @@
             }
         }
     };
+
     OperatorPreferencesWindowMenu.prototype.show = function show(ioperator, parentWindow) {
         var i, prefs, pref, fields;
 

--- a/src/wirecloud/platform/static/js/wirecloud/ui/OperatorPreferencesWindowMenu.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/OperatorPreferencesWindowMenu.js
@@ -32,7 +32,7 @@
     utils.inherit(OperatorPreferencesWindowMenu, Wirecloud.ui.WindowMenu);
 
     OperatorPreferencesWindowMenu.prototype._savePrefs = function _savePrefs(form, new_values) {
-        var key, details;
+        var key;
 
         for (key in new_values) {
             if (this._current_ioperator.preferences[key].value !== new_values[key]) {
@@ -42,18 +42,31 @@
             }
         }
 
+        this.hide();
+
+        Wirecloud.io.makeRequest(Wirecloud.URLs.OPERATOR_PREFERENCES.evaluate({
+                workspace_id: this._current_ioperator.wiring.workspace.id,
+                operator_id: this._current_ioperator.id
+            }), {
+                method: 'POST',
+                contentType: 'application/json',
+                requestHeaders: {'Accept': 'application/json'},
+                postBody: JSON.stringify(new_values),
+                onSuccess: operatorCallback.call(this, new_values)
+            }
+        );
+    };
+
+    var operatorCallback = function operatorCallback(new_values) {
         if (typeof this._current_ioperator.prefCallback === 'function') {
             try {
                 this._current_ioperator.prefCallback(new_values);
             } catch (error) {
-                details = this._current_ioperator.logManager.formatException(error);
+                var details = this._current_ioperator.logManager.formatException(error);
                 this._current_ioperator.logManager.log(utils.gettext('Exception catched while processing preference changes'), {details: details});
             }
         }
-
-        this.hide();
     };
-
     OperatorPreferencesWindowMenu.prototype.show = function show(ioperator, parentWindow) {
         var i, prefs, pref, fields;
 

--- a/src/wirecloud/platform/static/js/wirecloud/ui/OperatorPreferencesWindowMenu.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/OperatorPreferencesWindowMenu.js
@@ -49,17 +49,19 @@
 
         this.hide();
 
-        Wirecloud.io.makeRequest(Wirecloud.URLs.OPERATOR_PREFERENCES.evaluate({
-                workspace_id: this._current_ioperator.wiring.workspace.id,
-                operator_id: this._current_ioperator.id
-            }), {
-                method: 'POST',
-                contentType: 'application/json',
-                requestHeaders: {'Accept': 'application/json'},
-                postBody: JSON.stringify(new_values),
-                onSuccess: operatorCallback.call(this, new_values)
-            }
-        );
+        if (!this._current_ioperator.volatile) {
+            Wirecloud.io.makeRequest(Wirecloud.URLs.OPERATOR_PREFERENCES.evaluate({
+                    workspace_id: this._current_ioperator.wiring.workspace.id,
+                    operator_id: this._current_ioperator.id
+                }), {
+                    method: 'POST',
+                    contentType: 'application/json',
+                    requestHeaders: {'Accept': 'application/json'},
+                    postBody: JSON.stringify(new_values),
+                    onSuccess: operatorCallback.call(this, new_values)
+                }
+            );
+        }
     };
 
     var operatorCallback = function operatorCallback(new_values) {

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WiringEditor.js
@@ -256,9 +256,11 @@ Wirecloud.ui = Wirecloud.ui || {};
             button.disable();
 
             if (group.meta.type === 'operator') {
-                this.workspace.wiring.createOperator(group.meta).then(function (operator) {
+                this.workspace.wiring.createOperator(group.meta).then((operator) => {
                     button.enable();
                     showcase.addComponent(operator);
+                }, (error) => {
+                    button.enable();
                 });
             } else {
                 this.workspace.view.activeTab.createWidget(group.meta).then(function (widgetView) {

--- a/src/wirecloud/platform/tests/rest_api.py
+++ b/src/wirecloud/platform/tests/rest_api.py
@@ -1090,74 +1090,7 @@ class ApplicationMashupAPI(WirecloudTestCase):
         url = reverse('wirecloud.workspace_wiring', kwargs={'workspace_id': 1})
         check_put_bad_request_syntax(self, url)
 
-    def test_workspace_update_operator_preferences_requires_permission(self):
 
-        url = reverse('wirecloud.workspace_operatorpref', kwargs={'workspace_id': 202, "operator_id": 2})
-        data = {
-            'pref_secure': 'helloWorld'
-        }
-        check_post_requires_authentication(self, url, json.dumps(data))
-
-    def test_workspace_update_operator_preferences_post(self):
-
-        url = reverse('wirecloud.workspace_operatorpref', kwargs={'workspace_id': 202, "operator_id": 2})
-
-        data = {
-            'pref_secure': 'helloWorld'
-        }
-
-        # Authenticate
-        self.client.login(username='user_with_workspaces', password='admin')
-
-        response = self.client.post(url, json.dumps(data), content_type='application/json; charset=UTF-8')
-        self.assertEqual(response.status_code, 204)
-
-        # Check if preferences changed
-        self.assertEqual(Workspace.objects.get(pk=202).wiringStatus["operators"]["2"]["preferences"]["pref_secure"]["value"], "helloWorld")
-
-    def test_workspace_update_operator_preferences_read_only_permission(self):
-        url = reverse('wirecloud.workspace_operatorpref', kwargs={'workspace_id': 202, "operator_id": 2})
-
-        data = {
-            'username': 'helloWorld'
-        }
-
-        # Authenticate
-        self.client.login(username='user_with_workspaces', password='admin')
-
-        response = self.client.post(url, json.dumps(data), content_type='application/json; charset=UTF-8')
-        self.assertEqual(response.status_code, 403)
-
-        # Check if preferences changed
-        self.assertEqual(Workspace.objects.get(pk=202).wiringStatus["operators"]["2"]["preferences"]["username"]["value"], "test_username")
-
-    def test_workspace_update_operator_preferences_no_changes(self):
-
-        url = reverse('wirecloud.workspace_operatorpref', kwargs={'workspace_id': 202, "operator_id": 1})
-
-        data = {
-        }
-
-        # Authenticate
-        self.client.login(username='user_with_workspaces', password='admin')
-
-        response = self.client.post(url, json.dumps(data), content_type='application/json; charset=UTF-8')
-        self.assertEqual(response.status_code, 204)
-
-    def test_workspace_update_operator_preferences_does_not_exist(self):
-        url = reverse('wirecloud.workspace_operatorpref', kwargs={'workspace_id': 202, "operator_id": 1})
-
-        data = {
-            "doesNotExist": "helloWorld"
-        }
-
-        # Authenticate
-        self.client.login(username='user_with_workspaces', password='admin')
-
-        response = self.client.post(url, json.dumps(data), content_type='application/json; charset=UTF-8')
-        self.assertEqual(response.status_code, 400)
-
-        self.assertFalse("doesNotExist" in Workspace.objects.get(pk=202).wiringStatus["operators"]["2"]["preferences"])
 
     def test_tab_collection_post_requires_authentication(self):
 
@@ -2400,6 +2333,74 @@ class ApplicationMashupAPI(WirecloudTestCase):
         # IWidget should not be deleted
         IWidget.objects.get(pk=4)
 
+    def test_operator_preferences_entry_post(self):
+
+        url = reverse('wirecloud.workspace_operator_preferences', kwargs={'workspace_id': 202, "operator_id": 2})
+
+        data = {
+            'pref_secure': 'helloWorld'
+        }
+
+        # Authenticate
+        self.client.login(username='user_with_workspaces', password='admin')
+
+        response = self.client.post(url, json.dumps(data), content_type='application/json; charset=UTF-8')
+        self.assertEqual(response.status_code, 204)
+
+        # Check if preferences changed
+        self.assertEqual(Workspace.objects.get(pk=202).wiringStatus["operators"]["2"]["preferences"]["pref_secure"]["value"], "helloWorld")
+
+    def test_operator_preferences_entry_post_read_only_permission(self):
+        url = reverse('wirecloud.workspace_operator_preferences', kwargs={'workspace_id': 202, "operator_id": 2})
+
+        data = {
+            'username': 'helloWorld'
+        }
+
+        # Authenticate
+        self.client.login(username='user_with_workspaces', password='admin')
+
+        response = self.client.post(url, json.dumps(data), content_type='application/json; charset=UTF-8')
+        self.assertEqual(response.status_code, 403)
+
+        # Check if preferences changed
+        self.assertEqual(Workspace.objects.get(pk=202).wiringStatus["operators"]["2"]["preferences"]["username"]["value"], "test_username")
+
+    def test_operator_preferences_entry_post_empty_request(self):
+
+        url = reverse('wirecloud.workspace_operator_preferences', kwargs={'workspace_id': 202, "operator_id": 1})
+
+        data = {
+        }
+
+        # Authenticate
+        self.client.login(username='user_with_workspaces', password='admin')
+
+        response = self.client.post(url, json.dumps(data), content_type='application/json; charset=UTF-8')
+        self.assertEqual(response.status_code, 204)
+
+    def test_operator_preferences_entry_post_nonexistent_preference(self):
+        url = reverse('wirecloud.workspace_operator_preferences', kwargs={'workspace_id': 202, "operator_id": 1})
+
+        data = {
+            "doesNotExist": "helloWorld"
+        }
+
+        # Authenticate
+        self.client.login(username='user_with_workspaces', password='admin')
+
+        response = self.client.post(url, json.dumps(data), content_type='application/json; charset=UTF-8')
+        self.assertEqual(response.status_code, 400)
+
+        self.assertFalse("doesNotExist" in Workspace.objects.get(pk=202).wiringStatus["operators"]["2"]["preferences"])
+
+    def test_operator_preferences_entry_post_requires_permission(self):
+
+        url = reverse('wirecloud.workspace_operator_preferences', kwargs={'workspace_id': 202, "operator_id": 2})
+        data = {
+            'pref_secure': 'helloWorld'
+        }
+        check_post_requires_authentication(self, url, json.dumps(data))
 
 class ResourceManagementAPI(WirecloudTestCase):
 

--- a/src/wirecloud/platform/tests/rest_api.py
+++ b/src/wirecloud/platform/tests/rest_api.py
@@ -1143,12 +1143,12 @@ class ApplicationMashupAPI(WirecloudTestCase):
         # Make the request
         def patch_workspace_wiring():
             response = self.client.patch(url, data, content_type='application/json-patch+json; charset=UTF-8', HTTP_ACCEPT='application/json')
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 204)
 
             # Workspace wiring status should have change
             workspace = Workspace.objects.get(id=1)
             self.assertEqual(workspace.wiringStatus["operators"], new_wiring_status["operators"])
-        check_cache_is_purged(self, 1, update_workspace_wiring)
+        check_cache_is_purged(self, 1, patch_workspace_wiring)
 
     def test_workspace_wiring_entry_patch_not_found(self):
 
@@ -1160,9 +1160,11 @@ class ApplicationMashupAPI(WirecloudTestCase):
         data = json.dumps([{
             'op': "add",
             'path': "/operators/0",
-            'value': new_wiring_status["operators"]["0"],
+            'value': {'name': 'Wirecloud/TestOperator/1.0', 'preferences': {}}
         }])
-        check_not_found_response(self, 'patch', url, json.dumps(data))
+
+        response = self.client.patch(url, data, content_type='application/json-patch+json; charset=UTF-8', HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 404)
 
     def test_tab_collection_post_requires_authentication(self):
 
@@ -2462,7 +2464,7 @@ class ApplicationMashupAPI(WirecloudTestCase):
         self.client.login(username='user_with_workspaces', password='admin')
 
         response = self.client.post(url, json.dumps(data), content_type='application/json; charset=UTF-8')
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 422)
 
         self.assertFalse("doesNotExist" in Workspace.objects.get(pk=202).wiringStatus["operators"]["2"]["preferences"])
 

--- a/src/wirecloud/platform/tests/rest_api.py
+++ b/src/wirecloud/platform/tests/rest_api.py
@@ -1232,6 +1232,17 @@ class ApplicationMashupAPI(WirecloudTestCase):
 
         self.assertFalse("doesNotExist" in Workspace.objects.get(pk=202).wiringStatus["operators"]["2"]["preferences"])
 
+    def test_workspace_wiring_entry_patch_invalid_patch_operation(self):
+        url = reverse('wirecloud.workspace_wiring', kwargs={'workspace_id': 202})
+
+        data = {"this": "isNotAPatch"}
+
+        # Authenticate
+        self.client.login(username='user_with_workspaces', password='admin')
+
+        response = self.client.patch(url, json.dumps(data), content_type='application/json-patch+json; charset=UTF-8')
+        self.assertEqual(response.status_code, 400)
+
 
     def test_tab_collection_post_requires_authentication(self):
 

--- a/src/wirecloud/platform/urls.py
+++ b/src/wirecloud/platform/urls.py
@@ -173,6 +173,11 @@ urlpatterns = (
         name='wirecloud.workspace_wiring'
     ),
 
+    url(r'^api/workspace/(?P<workspace_id>\d+)/operatorpref/(?P<operator_id>\d+)$',
+        wiring_views.OperatorPreferencesEntry(permitted_methods=('POST',)),
+        name='wirecloud.workspace_operatorpref'
+    ),
+
     url(r'^api/workspace/(?P<to_ws_id>\d+)/merge/?$',
         workspace_views.MashupMergeService(),
         name='wirecloud.workspace_merge'

--- a/src/wirecloud/platform/urls.py
+++ b/src/wirecloud/platform/urls.py
@@ -169,7 +169,7 @@ urlpatterns = (
     ),
 
     url(r'^api/workspace/(?P<workspace_id>\d+)/wiring$',
-        wiring_views.WiringEntry(permitted_methods=('PUT',)),
+        wiring_views.WiringEntry(permitted_methods=('PUT', 'PATCH')),
         name='wirecloud.workspace_wiring'
     ),
 

--- a/src/wirecloud/platform/urls.py
+++ b/src/wirecloud/platform/urls.py
@@ -173,9 +173,9 @@ urlpatterns = (
         name='wirecloud.workspace_wiring'
     ),
 
-    url(r'^api/workspace/(?P<workspace_id>\d+)/operatorpref/(?P<operator_id>\d+)$',
+    url(r'^api/workspace/(?P<workspace_id>\d+)/wiring/operator/(?P<operator_id>\d+)/preferences/?$',
         wiring_views.OperatorPreferencesEntry(permitted_methods=('POST',)),
-        name='wirecloud.workspace_operatorpref'
+        name='wirecloud.workspace_operator_preferences'
     ),
 
     url(r'^api/workspace/(?P<to_ws_id>\d+)/merge/?$',

--- a/src/wirecloud/platform/urls.py
+++ b/src/wirecloud/platform/urls.py
@@ -173,11 +173,6 @@ urlpatterns = (
         name='wirecloud.workspace_wiring'
     ),
 
-    url(r'^api/workspace/(?P<workspace_id>\d+)/wiring/operator/(?P<operator_id>\d+)/preferences/?$',
-        wiring_views.OperatorPreferencesEntry(permitted_methods=('POST',)),
-        name='wirecloud.workspace_operator_preferences'
-    ),
-
     url(r'^api/workspace/(?P<to_ws_id>\d+)/merge/?$',
         workspace_views.MashupMergeService(),
         name='wirecloud.workspace_merge'

--- a/src/wirecloud/platform/wiring/views.py
+++ b/src/wirecloud/platform/wiring/views.py
@@ -36,7 +36,7 @@ from wirecloud.platform.wiring.utils import generate_xhtml_operator_code, get_op
 
 class WiringEntry(Resource):
 
-    def checkWiring(self, new_wiring_status, old_wiring_status, can_update_secure = False):
+    def checkWiring(self, request, new_wiring_status, old_wiring_status, can_update_secure = False):
         # Check read only connections
         old_read_only_connections = [connection for connection in old_wiring_status['connections'] if connection.get('readonly', False)]
         new_read_only_connections = [connection for connection in new_wiring_status['connections'] if connection.get('readonly', False)]
@@ -91,7 +91,7 @@ class WiringEntry(Resource):
         new_wiring_status = parse_json_request(request)
         old_wiring_status = workspace.wiringStatus
 
-        self.checkWiring(new_wiring_status, old_wiring_status)
+        self.checkWiring(request, new_wiring_status, old_wiring_status)
 
         workspace.wiringStatus = new_wiring_status
         workspace.save()
@@ -109,7 +109,7 @@ class WiringEntry(Resource):
 
         new_wiring_status = jsonpatch.apply_patch(old_wiring_status, parse_json_request(request))
 
-        self.checkWiring(new_wiring_status, old_wiring_status, can_update_secure = True)
+        self.checkWiring(request, new_wiring_status, old_wiring_status, can_update_secure = True)
 
         workspace.wiringStatus = new_wiring_status
         workspace.save()

--- a/src/wirecloud/platform/wiring/views.py
+++ b/src/wirecloud/platform/wiring/views.py
@@ -112,6 +112,8 @@ class OperatorPreferencesEntry(Resource):
         if len(new_values):
             operator_prefs = workspace.wiringStatus["operators"][operator_id]["preferences"]
             for preference in new_values:
+                if not preference in operator_prefs:
+                    return  build_error_response(request, 400, _("Preference does not exist"))
                 if operator_prefs[preference].get('readonly', False):
                     return build_error_response(request, 403, _('Read only preferences cannot be updated'))
                 else:

--- a/src/wirecloud/platform/wiring/views.py
+++ b/src/wirecloud/platform/wiring/views.py
@@ -78,6 +78,9 @@ class WiringEntry(Resource):
 
                 if new_preference.get('readonly', False) and new_preference.get('value') != old_preference.get('value'):
                     return build_error_response(request, 403, _('Read only preferences cannot be updated'))
+
+                if old_preference.get("secure", False) and not can_update_secure:
+                    new_preference["value"] = old_preference["value"]
         return True
 
 

--- a/src/wirecloud/platform/wiring/views.py
+++ b/src/wirecloud/platform/wiring/views.py
@@ -78,6 +78,7 @@ class WiringEntry(Resource):
 
                 if new_preference.get('readonly', False) and new_preference.get('value') != old_preference.get('value'):
                     return build_error_response(request, 403, _('Read only preferences cannot be updated'))
+        return True
 
 
     @authentication_required
@@ -91,7 +92,9 @@ class WiringEntry(Resource):
         new_wiring_status = parse_json_request(request)
         old_wiring_status = workspace.wiringStatus
 
-        self.checkWiring(request, new_wiring_status, old_wiring_status)
+        result = self.checkWiring(request, new_wiring_status, old_wiring_status)
+        if result != True:
+            return result
 
         workspace.wiringStatus = new_wiring_status
         workspace.save()
@@ -109,7 +112,9 @@ class WiringEntry(Resource):
 
         new_wiring_status = jsonpatch.apply_patch(old_wiring_status, parse_json_request(request))
 
-        self.checkWiring(request, new_wiring_status, old_wiring_status, can_update_secure = True)
+        result = self.checkWiring(request, new_wiring_status, old_wiring_status, can_update_secure = True)
+        if result != True:
+            return result
 
         workspace.wiringStatus = new_wiring_status
         workspace.save()

--- a/src/wirecloud/platform/wiring/views.py
+++ b/src/wirecloud/platform/wiring/views.py
@@ -36,7 +36,7 @@ from wirecloud.platform.wiring.utils import generate_xhtml_operator_code, get_op
 
 class WiringEntry(Resource):
 
-    def checkWiring(self, request, new_wiring_status, old_wiring_status, can_update_secure = False):
+    def checkWiring(self, request, new_wiring_status, old_wiring_status, can_update_secure=False):
         # Check read only connections
         old_read_only_connections = [connection for connection in old_wiring_status['connections'] if connection.get('readonly', False)]
         new_read_only_connections = [connection for connection in new_wiring_status['connections'] if connection.get('readonly', False)]
@@ -83,7 +83,6 @@ class WiringEntry(Resource):
                     new_preference["value"] = old_preference["value"]
         return True
 
-
     @authentication_required
     @consumes(('application/json',))
     def update(self, request, workspace_id):
@@ -96,7 +95,7 @@ class WiringEntry(Resource):
         old_wiring_status = workspace.wiringStatus
 
         result = self.checkWiring(request, new_wiring_status, old_wiring_status)
-        if result != True:
+        if result is not True:
             return result
 
         workspace.wiringStatus = new_wiring_status
@@ -106,7 +105,7 @@ class WiringEntry(Resource):
 
     @authentication_required
     @consumes(('application/json-patch+json',))
-    def patch (self, request, workspace_id):
+    def patch(self, request, workspace_id):
         workspace = get_object_or_404(Workspace, id=workspace_id)
         if not request.user.is_superuser and workspace.creator != request.user:
             return build_error_response(request, 403, _('You are not allowed to update this workspace'))
@@ -115,8 +114,8 @@ class WiringEntry(Resource):
 
         new_wiring_status = jsonpatch.apply_patch(old_wiring_status, parse_json_request(request))
 
-        result = self.checkWiring(request, new_wiring_status, old_wiring_status, can_update_secure = True)
-        if result != True:
+        result = self.checkWiring(request, new_wiring_status, old_wiring_status, can_update_secure=True)
+        if result is not True:
             return result
 
         workspace.wiringStatus = new_wiring_status
@@ -129,11 +128,12 @@ def process_requirements(requirements):
 
     return dict((requirement['name'], {}) for requirement in requirements)
 
+
 class OperatorPreferencesEntry(Resource):
 
     @authentication_required
     @consumes(('application/json',))
-    def create (self, request, workspace_id, operator_id):
+    def create(self, request, workspace_id, operator_id):
 
         workspace = get_object_or_404(Workspace, id=workspace_id)
         if not request.user.is_superuser and workspace.creator != request.user:
@@ -143,8 +143,8 @@ class OperatorPreferencesEntry(Resource):
         if len(new_values):
             operator_prefs = workspace.wiringStatus["operators"][operator_id]["preferences"]
             for preference in new_values:
-                if not preference in operator_prefs:
-                    return  build_error_response(request, 422, _("Preference does not exist"))
+                if preference not in operator_prefs:
+                    return build_error_response(request, 422, _("Preference does not exist"))
                 if operator_prefs[preference].get('readonly', False):
                     return build_error_response(request, 403, _('Read only preferences cannot be updated'))
                 else:
@@ -154,13 +154,14 @@ class OperatorPreferencesEntry(Resource):
 
         return HttpResponse(status=204)
 
+
 class OperatorEntry(Resource):
 
     def read(self, request, vendor, name, version):
 
         operator = get_object_or_404(CatalogueResource, type=2, vendor=vendor, short_name=name, version=version)
         # For now, all operators are freely accessible/distributable
-        #if not operator.is_available_for(request.user):
+        # if not operator.is_available_for(request.user):
         #    return HttpResponseForbidden()
 
         mode = request.GET.get('mode', 'classic')

--- a/src/wirecloud/platform/wiring/views.py
+++ b/src/wirecloud/platform/wiring/views.py
@@ -122,7 +122,7 @@ class WiringEntry(Resource):
         workspace.wiringStatus = new_wiring_status
         workspace.save()
 
-        return HttpResponse(status=200)
+        return HttpResponse(status=204)
 
 
 def process_requirements(requirements):
@@ -144,7 +144,7 @@ class OperatorPreferencesEntry(Resource):
             operator_prefs = workspace.wiringStatus["operators"][operator_id]["preferences"]
             for preference in new_values:
                 if not preference in operator_prefs:
-                    return  build_error_response(request, 400, _("Preference does not exist"))
+                    return  build_error_response(request, 422, _("Preference does not exist"))
                 if operator_prefs[preference].get('readonly', False):
                     return build_error_response(request, 403, _('Read only preferences cannot be updated'))
                 else:

--- a/src/wirecloud/platform/wiring/views.py
+++ b/src/wirecloud/platform/wiring/views.py
@@ -132,6 +132,8 @@ class WiringEntry(Resource):
             new_wiring_status = jsonpatch.apply_patch(old_wiring_status, parse_json_request(request))
         except jsonpatch.JsonPointerException:
             return build_error_response(request, 422, _('Failed to apply patch'))
+        except jsonpatch.InvalidJsonPatch:
+            return build_error_response(request, 400, _('Invalid JSON patch'))
 
         result = self.checkWiring(request, new_wiring_status, old_wiring_status, can_update_secure=True)
         if result is not True:

--- a/src/wirecloud/platform/workspace/tests.py
+++ b/src/wirecloud/platform/workspace/tests.py
@@ -64,11 +64,32 @@ class WorkspaceTestCase(WirecloudTestCase):
 
         tab = data['tabs'][0]
         preferences = tab['iwidgets'][0]['preferences']
-        self.assertEqual(preferences['password']['value'], '')
+        self.assertEqual(preferences['password']['value'], '********')
         self.assertEqual(preferences['password']['secure'], True)
         self.assertEqual(preferences['username']['value'], 'test_username')
         properties = tab['iwidgets'][0]['properties']
         self.assertEqual(properties['prop']['value'], 'test_data')
+
+    def test_secure_preferences_censor (self):
+        workspace = Workspace.objects.get(pk=202)
+        data = json.loads(get_global_workspace_data(workspace, self.user).get_data())
+        self.assertEqual(len(data['tabs']), 1)
+
+        tab = data['tabs'][0]
+        preferences = tab['iwidgets'][0]['preferences']
+        self.assertEqual(preferences['password']['value'], '')
+        self.assertEqual(preferences['password']['secure'], True)
+
+        tab = data['tabs'][0]
+        preferences = tab['iwidgets'][1]['preferences']
+        self.assertEqual(preferences['password']['value'], '********')
+        self.assertEqual(preferences['password']['secure'], True)
+
+        self.assertEqual(data["wiring"]["operators"]["1"]["preferences"]["pref_secure"]['secure'], True)
+        self.assertEqual(data["wiring"]["operators"]["1"]["preferences"]["pref_secure"]["value"], "")
+
+        self.assertEqual(data["wiring"]["operators"]["2"]["preferences"]["pref_secure"]['secure'], True)
+        self.assertEqual(data["wiring"]["operators"]["2"]["preferences"]["pref_secure"]["value"], "********")
 
     def test_create_empty_workspace(self):
 
@@ -129,7 +150,7 @@ class WorkspaceCacheTestCase(WirecloudTestCase):
 
         data = json.loads(workspace_info.get_data())
         preferences = data['tabs'][0]['iwidgets'][0]['preferences']
-        self.assertEqual(preferences['password']['value'], '')
+        self.assertEqual(preferences['password']['value'], '********')
         self.assertEqual(preferences['password']['secure'], True)
         self.assertEqual(preferences['username']['value'], 'new_username')
         properties = data['tabs'][0]['iwidgets'][0]['properties']
@@ -146,7 +167,7 @@ class WorkspaceCacheTestCase(WirecloudTestCase):
 
         data = json.loads(get_global_workspace_data(self.workspace, self.user).get_data())
         preferences = data['tabs'][0]['iwidgets'][0]['preferences']
-        self.assertEqual(preferences['password']['value'], '')
+        self.assertEqual(preferences['password']['value'], '********')
         self.assertEqual(preferences['password']['secure'], True)
         self.assertEqual(preferences['username']['value'], 'test_username')
         properties = data['tabs'][0]['iwidgets'][0]['properties']

--- a/src/wirecloud/platform/workspace/utils.py
+++ b/src/wirecloud/platform/workspace/utils.py
@@ -282,12 +282,19 @@ class VariableValueCacheManager():
     def get_variable_data(self, iwidget, var_name):
         values = self.get_variable_values()
         entry = values['by_varname'][iwidget.id][var_name]
+
+        # If secure and has value, censor it
+        if entry["secure"] and entry["value"] != "":
+            value = "********"
+        else:
+            value = entry["value"]
+
         return {
             'name': var_name,
             'secure': entry['secure'],
             'readonly': entry['readonly'],
             'hidden': entry['hidden'],
-            'value': '' if entry['secure'] else entry['value']
+            'value': value,
         }
 
 
@@ -473,7 +480,8 @@ def _get_global_workspace_data(workspaceDAO, user):
                 preference['value'] = operator_forced_values[preference_name]['value']
             elif preference.get('value') is None and vardef is not None:
                 preference['value'] = parse_value_from_text(vardef, vardef['default'])
-
+            if vardef is not None and vardef["secure"]:
+                preference['value'] = "" if preference.get('value') is None or preference.get('value') == "" else "********"
     return json.dumps(data_ret, cls=LazyEncoder)
 
 

--- a/src/wirecloud/proxy/processors.py
+++ b/src/wirecloud/proxy/processors.py
@@ -34,22 +34,23 @@ from wirecloud.proxy.utils import ValidationError
 
 WIRECLOUD_SECURE_DATA_HEADER = 'x-wirecloud-secure-data'
 WIRECLOUD_COMPONENT_TYPE_HEADER = 'wirecloud-component-type'
-VAR_REF_RE = re.compile(r'^(?P<iwidget_id>[1-9]\d*|c)/(?P<var_name>.+)$', re.S)
+WIRECLOUD_COMPONENT_ID_HEADER = 'wirecloud-component-id'
+
+VAR_REF_RE = re.compile(r'^((?P<constant>c)/)?(?P<var_name>.+)$', re.S)
 
 
-def get_variable_value_by_ref(ref, cache_manager, component_type="widget"):
-
+def get_variable_value_by_ref(ref, cache_manager, component_id, component_type="widget"):
     result = VAR_REF_RE.match(ref)
     try:
         # Get widget variables
         if component_type == "widget":
-            if result.group('iwidget_id') == 'c':
+            if result.group('constant') == 'c':
                 return result.group('var_name')
             else:
-                return cache_manager.get_variable_value_from_varname(result.group('iwidget_id'), result.group('var_name'))
+                return cache_manager.get_variable_value_from_varname(component_id, result.group('var_name'))
         # Get operator variables
         elif component_type == "operator":
-            return cache_manager.workspace.wiringStatus["operators"][result.group('iwidget_id')]["preferences"][result.group('var_name')]["value"]
+            return cache_manager.workspace.wiringStatus["operators"][component_id]["preferences"][result.group('var_name')]["value"]
 
         else:
             raise ValidationError()
@@ -83,7 +84,7 @@ def check_invalid_refs(**kargs):
         raise ValidationError(msg % {'params': ', '.join(invalid_params)})
 
 
-def process_secure_data(text, request, component_type):
+def process_secure_data(text, request, component_id, component_type):
 
     definitions = text.split('&')
     cache_manager = VariableValueCacheManager(request['workspace'], request['user'])
@@ -104,8 +105,7 @@ def process_secure_data(text, request, component_type):
             var_ref = options.get('var_ref', '')
             check_empty_params(substr=substr, var_ref=var_ref)
 
-            value = get_variable_value_by_ref(var_ref, cache_manager, component_type)
-
+            value = get_variable_value_by_ref(var_ref, cache_manager, component_id, component_type)
             check_invalid_refs(var_ref=value)
 
             encoding = options.get('encoding', 'none')
@@ -127,8 +127,8 @@ def process_secure_data(text, request, component_type):
             password_ref = options.get('pass_ref', '')
             check_empty_params(user_ref=user_ref, password_ref=password_ref)
 
-            user_value = get_variable_value_by_ref(user_ref, cache_manager, component_type)
-            password_value = get_variable_value_by_ref(password_ref, cache_manager, component_type)
+            user_value = get_variable_value_by_ref(user_ref, cache_manager, component_id, component_type)
+            password_value = get_variable_value_by_ref(password_ref, cache_manager, component_id, component_type)
             check_invalid_refs(user_ref=user_value, password_ref=password_value)
 
             token = base64.b64encode((user_value + ':' + password_value).encode('utf8'))[:-1]
@@ -145,5 +145,6 @@ class SecureDataProcessor(object):
         if WIRECLOUD_SECURE_DATA_HEADER in request['headers']:
             secure_data_value = request['headers'][WIRECLOUD_SECURE_DATA_HEADER]
             component_type = request['headers'].get(WIRECLOUD_COMPONENT_TYPE_HEADER, "widget")
-            process_secure_data(secure_data_value, request, component_type)
+            component_id = request['headers'].get(WIRECLOUD_COMPONENT_ID_HEADER, "")
+            process_secure_data(secure_data_value, request, component_id, component_type)
             del request['headers'][WIRECLOUD_SECURE_DATA_HEADER]

--- a/src/wirecloud/proxy/processors.py
+++ b/src/wirecloud/proxy/processors.py
@@ -144,6 +144,6 @@ class SecureDataProcessor(object):
         # Process secure data from the X-WireCloud-Secure-Data header
         if WIRECLOUD_SECURE_DATA_HEADER in request['headers']:
             secure_data_value = request['headers'][WIRECLOUD_SECURE_DATA_HEADER]
-            component_type = request['headers'][WIRECLOUD_COMPONENT_TYPE_HEADER]
+            component_type = request['headers'].get(WIRECLOUD_COMPONENT_TYPE_HEADER, "widget")
             process_secure_data(secure_data_value, request, component_type)
             del request['headers'][WIRECLOUD_SECURE_DATA_HEADER]

--- a/src/wirecloud/proxy/tests.py
+++ b/src/wirecloud/proxy/tests.py
@@ -455,13 +455,15 @@ class ProxySecureDataTests(ProxyTestsBase):
 
         self.network._servers['http']['example.com'].add_response('POST', '/path', echo_response)
 
-        secure_data_header = 'action=basic_auth, user_ref=' + user_ref + ', pass_ref=' + pass_ref + ", type = operator"
+        secure_data_header = 'action=basic_auth, user_ref=' + user_ref + ', pass_ref=' + pass_ref
+
         response = self.client.post(self.basic_url,
                             'username=|username|&password=|password|',
                             content_type='application/x-www-form-urlencoded',
                             HTTP_HOST='localhost',
                             HTTP_REFERER='http://localhost/test/workspaceSecure',
-                            HTTP_X_WIRECLOUD_SECURE_DATA=secure_data_header)
+                            HTTP_X_WIRECLOUD_SECURE_DATA=secure_data_header,
+                            HTTP_WIRECLOUD_COMPONENT_TYPE="operator")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.read_response(response), b'username=|username|&password=|password|')

--- a/src/wirecloud/proxy/tests.py
+++ b/src/wirecloud/proxy/tests.py
@@ -446,8 +446,8 @@ class ProxySecureDataTests(ProxyTestsBase):
     tags = ('wirecloud-proxy', 'wirecloud-proxy-secure-data', 'wirecloud-noselenium')
 
     def test_secure_data_operator(self):
-        pass_ref = '2/pref_secure'
-        user_ref = '2/username'
+        pass_ref = 'pref_secure'
+        user_ref = 'username'
         self.client.login(username='test', password='test')
 
         def echo_response(method, url, *args, **kwargs):
@@ -463,7 +463,8 @@ class ProxySecureDataTests(ProxyTestsBase):
                             HTTP_HOST='localhost',
                             HTTP_REFERER='http://localhost/test/workspaceSecure',
                             HTTP_X_WIRECLOUD_SECURE_DATA=secure_data_header,
-                            HTTP_WIRECLOUD_COMPONENT_TYPE="operator")
+                            HTTP_WIRECLOUD_COMPONENT_TYPE="operator",
+                            HTTP_WIRECLOUD_COMPONENT_ID="2")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.read_response(response), b'username=|username|&password=|password|')
@@ -481,8 +482,8 @@ class ProxySecureDataTests(ProxyTestsBase):
             return {'status_code': 200, 'content': kwargs['data'].read()}
 
         self.network._servers['http']['example.com'].add_response('POST', '/path', echo_response)
-        pass_ref = '1/password'
-        user_ref = '1/username'
+        pass_ref = 'password'
+        user_ref = 'username'
         secure_data_header = 'action=data, substr=|password|, var_ref=' + pass_ref
         secure_data_header += '&action=data, substr=|username|, var_ref=' + user_ref
         response = self.client.post(self.basic_url,
@@ -490,7 +491,9 @@ class ProxySecureDataTests(ProxyTestsBase):
                             content_type='application/x-www-form-urlencoded',
                             HTTP_HOST='localhost',
                             HTTP_REFERER='http://localhost/test/workspace',
-                            HTTP_X_WIRECLOUD_SECURE_DATA=secure_data_header)
+                            HTTP_X_WIRECLOUD_SECURE_DATA=secure_data_header,
+                            HTTP_WIRECLOUD_COMPONENT_TYPE="widget",
+                            HTTP_WIRECLOUD_COMPONENT_ID="1")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.read_response(response), b'username=test_username&password=test_password')
@@ -501,7 +504,8 @@ class ProxySecureDataTests(ProxyTestsBase):
                             content_type='application/x-www-form-urlencoded',
                             HTTP_HOST='localhost',
                             HTTP_REFERER='http://localhost/test/workspace',
-                            HTTP_X_WIRECLOUD_SECURE_DATA=secure_data_header)
+                            HTTP_X_WIRECLOUD_SECURE_DATA=secure_data_header,
+                            HTTP_WIRECLOUD_COMPONENT_ID="1")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.read_response(response), b'username=|username|&password=|password|')
@@ -514,7 +518,8 @@ class ProxySecureDataTests(ProxyTestsBase):
                             content_type='application/x-www-form-urlencoded',
                             HTTP_HOST='localhost',
                             HTTP_REFERER='http://localhost/test/workspace',
-                            HTTP_X_WIRECLOUD_SECURE_DATA=secure_data_header)
+                            HTTP_X_WIRECLOUD_SECURE_DATA=secure_data_header,
+                            HTTP_WIRECLOUD_COMPONENT_ID="1")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.read_response(response), b'username=test_username&password=test_password')
@@ -527,19 +532,21 @@ class ProxySecureDataTests(ProxyTestsBase):
                             content_type='application/x-www-form-urlencoded',
                             HTTP_HOST='localhost',
                             HTTP_REFERER='http://localhost/test/workspace',
-                            HTTP_X_WIRECLOUD_SECURE_DATA=secure_data_header)
+                            HTTP_X_WIRECLOUD_SECURE_DATA=secure_data_header,
+                            HTTP_WIRECLOUD_COMPONENT_ID="1")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.read_response(response), b'username=a=, z&password=a%3D%2C%20z')
 
         # Secure data header using encoding=base64
-        secure_data_header = 'action=data, substr=|password|, var_ref=1/password, encoding=base64'
+        secure_data_header = 'action=data, substr=|password|, var_ref=password, encoding=base64'
         response = self.client.post(self.basic_url,
                             'username=|username|&password=|password|',
                             content_type='application/x-www-form-urlencoded',
                             HTTP_HOST='localhost',
                             HTTP_REFERER='http://localhost/test/workspace',
-                            HTTP_X_WIRECLOUD_SECURE_DATA=secure_data_header)
+                            HTTP_X_WIRECLOUD_SECURE_DATA=secure_data_header,
+                            HTTP_WIRECLOUD_COMPONENT_ID="1")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.read_response(response), b'username=|username|&password=dGVzdF9wYXNzd29yZA=')

--- a/src/wirecloud/proxy/tests.py
+++ b/src/wirecloud/proxy/tests.py
@@ -466,7 +466,6 @@ class ProxySecureDataTests(ProxyTestsBase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.read_response(response), b'username=|username|&password=|password|')
 
-    test_secure_data_operator.tags = ("current",)
     def test_secure_data(self):
 
         iwidget = IWidget.objects.get(pk=1)


### PR DESCRIPTION
Adds secure request support for operators

Adds secure preferences censorship (shows empty if no value provided and eight asterisks if it has any value.

Updates operator preferences on change instead of waiting to leave the wiring view.

`MashupPlatform.prefs.get("secure-preference-name")` can be used to get the display value of the preference (empty or 8 asterisks). This can be useful in order to check if the preference has any value.




 

