### PR TITLE
Fix get_workspace_data: Wrong censored operator variables being sent

### DIFF
--- a/src/wirecloud/commons/fixtures/user_with_workspaces.json
+++ b/src/wirecloud/commons/fixtures/user_with_workspaces.json
@@ -277,7 +277,7 @@
             "name": "workspaceSecure",
             "public": false,
             "creator": "4",
-            "wiringStatus": "{\"operators\": {\"1\": {\"name\": \"Wirecloud/TestOperatorSecure/1.0\", \"properties\": {}, \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"4\": \"\"}}}, \"username\": {\"secure\": false, \"readonly\": true, \"hidden\": false, \"value\": {\"users\": {\"4\": \"username\"}}}}}, \"2\": {\"name\": \"Wirecloud/TestOperatorSecure/1.0\", \"properties\": {}, \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"4\": \"test_password\"}}}, \"username\": {\"secure\": false, \"readonly\": true, \"hidden\": false, \"value\": {\"users\": {\"4\": \"test_username\"}}}}}}, \"connections\": []}"
+            "wiringStatus": "{\"operators\": {\"1\": {\"name\": \"Wirecloud/TestOperatorSecure/1.0\", \"properties\": {}, \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"4\": \"\"}}}, \"username\": {\"secure\": false, \"readonly\": true, \"hidden\": false, \"value\": {\"users\": {\"4\": \"username\"}}}}}, \"2\": {\"name\": \"Wirecloud/TestOperatorSecure/1.0\", \"properties\": {}, \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"4\": \"r16Ts7Ekgd4EuYggazdIqQ==\"}}}, \"username\": {\"secure\": false, \"readonly\": true, \"hidden\": false, \"value\": {\"users\": {\"4\": \"test_username\"}}}}}}, \"connections\": []}"
         }
     },
     {

--- a/src/wirecloud/platform/fixtures/test_data.json
+++ b/src/wirecloud/platform/fixtures/test_data.json
@@ -98,7 +98,7 @@
             "name": "workspaceSecure",
             "public": false,
             "creator": "2",
-            "wiringStatus": "{\"operators\": {\"1\": {\"name\": \"Wirecloud/TestOperatorSecure/1.0\", \"properties\": {}, \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"\"}}}, \"username\": {\"secure\": false, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"username\"}}}}}, \"2\": {\"name\": \"Wirecloud/TestOperatorSecure/1.0\", \"properties\": {}, \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"test_password\"}}}, \"username\": {\"secure\": false, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"test_username\"}}}}}}, \"connections\": []}"
+            "wiringStatus": "{\"operators\": {\"1\": {\"name\": \"Wirecloud/TestOperatorSecure/1.0\", \"properties\": {}, \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"\"}}}, \"username\": {\"secure\": false, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"username\"}}}}}, \"2\": {\"name\": \"Wirecloud/TestOperatorSecure/1.0\", \"properties\": {}, \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"r16Ts7Ekgd4EuYggazdIqQ==\"}}}, \"username\": {\"secure\": false, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"test_username\"}}}}}}, \"connections\": []}"
         }
     },
     {

--- a/src/wirecloud/platform/workspace/tests.py
+++ b/src/wirecloud/platform/workspace/tests.py
@@ -201,7 +201,7 @@ class WorkspaceTestCase(WirecloudTestCase):
                     },
                     'properties': {
                         'prop1': {'hidden': True, 'readonly': False, 'value': {"users": {"2": 'a'}}},
-                        'prop3': {'hidden': True, 'readonly': False, 'value': {"users": {"2": 'a'}}},
+                        'prop3': {'hidden': True, 'readonly': False, 'value': {"users": {"2": 'ImN5EbVtQ1ffc6BZp3rkNg=='}}},
                     }
                 },
             },

--- a/src/wirecloud/platform/workspace/utils.py
+++ b/src/wirecloud/platform/workspace/utils.py
@@ -511,7 +511,7 @@ def _get_global_workspace_data(workspaceDAO, user):
 
             # Secure censor
             if vardef is not None and vardef["secure"]:
-                preference['value'] = "" if preference.get('value') is None or preference.get('value') == "" else "********"
+                preference['value'] = "" if preference.get('value') is None or decrypt_value(preference.get('value')) == "" else "********"
 
         # Build operator property data
         for property_name, property in six.iteritems(operator.get('properties', {})):
@@ -531,7 +531,7 @@ def _get_global_workspace_data(workspaceDAO, user):
 
             # Secure censor
             if vardef is not None and vardef["secure"]:
-                property['value'] = "" if property.get('value') is None or property.get('value') == "" else "********"
+                property['value'] = "" if property.get('value') is None or decrypt_value(property.get('value')) == "" else "********"
 
     return json.dumps(data_ret, cls=LazyEncoder)
 


### PR DESCRIPTION
Secure operator variables check the decoded value before censoring it