### PR TITLE
Fix migrations for old operator structures

### DIFF
--- a/src/wirecloud/platform/migration_utils.py
+++ b/src/wirecloud/platform/migration_utils.py
@@ -29,7 +29,7 @@ import six
 
 
 def mutate_forwards_operator(preference, userID):
-    preference["value"] = {"users": {"%s" % userID: preference["value"]}}
+    preference["value"] = {"users": {"%s" % userID: preference.get("value", "")}}
     return preference
 
 
@@ -58,7 +58,7 @@ def multiuser_variables_structure_forwards(apps, schema_editor):
         # Update operators
         wiring = workspace.wiringStatus
         for op in wiring["operators"]:
-            wiring["operators"][op]["preferences"] = {k: mutate_forwards_operator(v, owner) for k, v in six.iteritems(wiring["operators"][op]["preferences"])}
+            wiring["operators"][op]["preferences"] = {k: mutate_forwards_operator(v, owner) for k, v in six.iteritems(wiring["operators"][op].get("preferences", {}))}
             wiring["operators"][op]["properties"] = {} # Create properties structure
         workspace.save()
 

--- a/src/wirecloud/platform/workspace/tests.py
+++ b/src/wirecloud/platform/workspace/tests.py
@@ -84,8 +84,9 @@ class WorkspaceMigrationsTestCase(TestCase):
         workspace_mock = Mock(
             wiringStatus={"operators": {
                 "1": {"preferences": {"varname": {"value": "varvalue"}, "varname2": {"value": "varvalue2"}}},
-                "2": {"preferences": {"varname": {"value": "hello"}, "varname2": {"value": "world"}}}}
-            })
+                "2": {"preferences": {"varname": {"value": "hello"}, "wrongvar1": {}}},
+                "3": {},
+            }})
         workspace_mock.tab_set.all.return_value = [tab_mock, tab_mock2]
         workspace_mock.creator.id = "2"
 
@@ -101,7 +102,9 @@ class WorkspaceMigrationsTestCase(TestCase):
 
         self.assertEqual(workspace_mock.wiringStatus, {"operators":
             {"1": {"properties": {}, "preferences": {"varname": {"value": {"users": {"2": "varvalue"}}}, "varname2": {"value": {"users": {"2": "varvalue2"}}}}},
-            "2": {"properties": {}, "preferences": {"varname": {"value": {"users": {"2": "hello"}}}, "varname2": {"value": {"users": {"2": "world"}}}}}}})
+            "2": {"properties": {}, "preferences": {"varname": {"value": {"users": {"2": "hello"}}}, "wrongvar1": {"value": {"users": {"2": ""}}}}},
+            "3":{"properties":{}, "preferences": {}}
+            }})
 
     def test_add_multiuser_support_backward_empty(self):
 


### PR DESCRIPTION
Add support for operators stored without the preferences key and for operator preferences without the value key.