### PR TITLE
Fix Mashup operator properties bug

### DIFF
--- a/src/wirecloud/platform/static/js/wirecloud/wiring/Operator.js
+++ b/src/wirecloud/platform/static/js/wirecloud/wiring/Operator.js
@@ -169,6 +169,7 @@
         id: "",
         name: "",
         preferences: {},
+        properties: {},
         volatile: false
     };
 

--- a/src/wirecloud/platform/workspace/mashupTemplateParser.py
+++ b/src/wirecloud/platform/workspace/mashupTemplateParser.py
@@ -305,6 +305,7 @@ def fillWorkspaceUsingTemplate(workspace, template):
             'id': new_id,
             'name': operator['name'],
             'preferences': operator['preferences'],
+            'properties': {}
         }
 
         ioperator_forced_values = {}


### PR DESCRIPTION
Fix operator properties not being created when creating the dashboard from a mashup template.