### PR TITLE
Add headers option to addComponent from URL

### DIFF
--- a/src/wirecloud/catalogue/static/js/wirecloud/WirecloudCatalogue.js
+++ b/src/wirecloud/catalogue/static/js/wirecloud/WirecloudCatalogue.js
@@ -218,6 +218,7 @@
             contentType = 'application/json';
             body = JSON.stringify({
                 url: options.url,
+                headers: options.headers,
                 force_create: !!options.forceCreate,
                 install_embedded_resources: !!options.install_embedded_resources,
                 market_endpoint: options.market_endpoint


### PR DESCRIPTION
Add support for a headers option when installing Wirecloud components from a URL.