### PR TITLE
Title cant be null migration

### DIFF
--- a/src/wirecloud/commons/fixtures/user_with_workspaces.json
+++ b/src/wirecloud/commons/fixtures/user_with_workspaces.json
@@ -160,6 +160,7 @@
         "fields": {
             "visible": true,
             "name": "Tab",
+            "title": "Tab",
             "workspace": 2,
             "position": 0
         }
@@ -170,6 +171,7 @@
         "fields": {
             "visible": true,
             "name": "Tab 1",
+            "title": "Tab 1",
             "workspace": 3,
             "position": 0
         }
@@ -180,6 +182,7 @@
         "fields": {
             "visible": false,
             "name": "Tab 2",
+            "title": "Tab 2",
             "workspace": 3,
             "position": 1
         }
@@ -190,6 +193,7 @@
         "fields": {
             "visible": true,
             "name": "Tab",
+            "title": "Tab",
             "workspace": 4,
             "position": 0
         }
@@ -200,6 +204,7 @@
         "fields": {
             "visible": true,
             "name": "Tab",
+            "title": "Tab",
             "workspace": 5,
             "position": 0
         }
@@ -210,6 +215,7 @@
         "fields": {
             "visible": true,
             "name": "Tab",
+            "title": "Tab",
             "workspace": 6,
             "position": 0
         }
@@ -221,6 +227,7 @@
             "forcedValues": "",
             "wiringStatus": "{\"connections\": [{\"source\": {\"type\": \"widget\", \"id\": 1, \"endpoint\": \"outputendpoint\"}, \"readonly\": false, \"target\": {\"type\": \"widget\", \"id\": 2, \"endpoint\": \"inputendpoint\"}}, {\"source\": {\"type\": \"widget\", \"id\": 2, \"endpoint\": \"outputendpoint\"}, \"readonly\": false, \"target\": {\"type\": \"operator\", \"id\": 0, \"endpoint\": \"input\"}}, {\"source\": {\"type\": \"operator\", \"id\": 0, \"endpoint\": \"output\"}, \"readonly\": false, \"target\": {\"type\": \"widget\", \"id\": 1, \"endpoint\": \"inputendpoint\"}}], \"operators\": {\"0\": {\"preferences\": {}, \"name\": \"Wirecloud/TestOperator/1.0\", \"properties\": {}, \"id\": \"0\"}}, \"version\": \"2.0\", \"visualdescription\": {\"connections\": [{\"sourcename\": \"widget/1/outputendpoint\", \"targethandle\": \"auto\", \"targetname\": \"widget/2/inputendpoint\", \"sourcehandle\": \"auto\"}, {\"sourcename\": \"widget/2/outputendpoint\", \"targethandle\": \"auto\", \"targetname\": \"operator/0/input\", \"sourcehandle\": \"auto\"}, {\"sourcename\": \"operator/0/output\", \"targethandle\": \"auto\", \"targetname\": \"widget/1/inputendpoint\", \"sourcehandle\": \"auto\"}], \"behaviours\": [], \"components\": {\"operator\": {\"0\": {\"position\": {\"y\": 20, \"x\": 440}, \"collapsed\": false, \"endpoints\": {\"source\": [\"output\"], \"target\": [\"input\"]}}}, \"widget\": {\"1\": {\"position\": {\"y\": 280, \"x\": 260}, \"name\": \"Wirecloud/Test/1.0\", \"properties\": {}, \"endpoints\": {\"source\": [\"outputendpoint\"], \"target\": [\"inputendpoint\"]}}, \"2\": {\"position\": {\"y\": 10, \"x\": 60}, \"name\": \"Wirecloud/Test/1.0\", \"properties\": {}, \"endpoints\": {\"source\": [\"outputendpoint\"], \"target\": [\"inputendpoint\"]}}}}}}",
             "name": "Workspace",
+            "title": "Workspace",
             "groups": [],
             "creator": 4
         }
@@ -257,6 +264,7 @@
             "forcedValues": "",
             "wiringStatus": "{\"connections\": [], \"operators\": {}, \"version\": \"2.0\", \"visualdescription\": {\"connections\": [], \"behaviours\": [], \"components\": {\"operator\": {}, \"widget\": {}}}}",
             "name": "WiringTests",
+            "title": "WiringTests",
             "groups": [],
             "creator": 4
         }
@@ -268,6 +276,7 @@
             "forcedValues": "",
             "wiringStatus": "{\"connections\": [{\"source\": {\"type\": \"widget\", \"id\": 10, \"endpoint\": \"outputendpoint\"}, \"readonly\": false, \"target\": {\"type\": \"widget\", \"id\": 11, \"endpoint\": \"inputendpoint\"}}, {\"source\": {\"type\": \"widget\", \"id\": 11, \"endpoint\": \"outputendpoint\"}, \"readonly\": false, \"target\": {\"type\": \"operator\", \"id\": 0, \"endpoint\": \"input\"}}, {\"source\": {\"type\": \"operator\", \"id\": 0, \"endpoint\": \"output\"}, \"readonly\": false, \"target\": {\"type\": \"widget\", \"id\": 10, \"endpoint\": \"inputendpoint\"}}], \"operators\": {\"0\": {\"preferences\": {}, \"name\": \"Wirecloud/TestOperator/1.0\", \"properties\": {}, \"id\": \"0\"}}, \"version\": \"2.0\", \"visualdescription\": {\"connections\": [{\"sourcename\": \"widget/10/outputendpoint\", \"targethandle\": \"auto\", \"targetname\": \"widget/11/inputendpoint\", \"sourcehandle\": \"auto\"}, {\"sourcename\": \"widget/11/outputendpoint\", \"targethandle\": \"auto\", \"targetname\": \"operator/0/input\", \"sourcehandle\": \"auto\"}, {\"sourcename\": \"operator/0/output\", \"targethandle\": \"auto\", \"targetname\": \"widget/10/inputendpoint\", \"sourcehandle\": \"auto\"}], \"behaviours\": [{\"title\": \"Test 1\", \"components\": {\"operator\": {\"0\": {}}, \"widget\": {\"11\": {}}}, \"connections\": [{\"sourcename\": \"widget/11/outputendpoint\", \"targetname\": \"operator/0/input\"}]}, {\"title\": \"Test 2\", \"components\": {\"operator\": {\"0\": {}}, \"widget\": {\"10\": {}, \"11\": {}}}, \"connections\": [{\"sourcename\": \"widget/11/outputendpoint\", \"targetname\": \"operator/0/input\"}, {\"sourcename\": \"operator/0/output\", \"targetname\": \"widget/10/inputendpoint\"}, {\"sourcename\": \"widget/10/outputendpoint\", \"targetname\": \"widget/11/inputendpoint\"}]}], \"components\": {\"operator\": {\"0\": {\"position\": {\"y\": 20, \"x\": 440}, \"collapsed\": false, \"endpoints\": {\"source\": [\"output\"], \"target\": [\"input\"]}}}, \"widget\": {\"10\": {\"position\": {\"y\": 280, \"x\": 260}, \"name\": \"Wirecloud/Test/1.0\", \"properties\": {}, \"endpoints\": {\"source\": [\"outputendpoint\"], \"target\": [\"inputendpoint\"]}}, \"11\": {\"position\": {\"y\": 10, \"x\": 60}, \"name\": \"Wirecloud/Test/1.0\", \"properties\": {}, \"endpoints\": {\"source\": [\"outputendpoint\"], \"target\": [\"inputendpoint\"]}}}}}}",
             "name": "WorkspaceBehaviours",
+            "title": "WorkspaceBehaviours",
             "groups": [],
             "creator": 4
         }
@@ -277,6 +286,7 @@
         "pk": 203,
         "fields": {
             "name": "workspaceMissing",
+            "title": "workspaceMissing",
             "public": false,
             "creator": "4",
             "wiringStatus": "{\"operators\": {\"1\": {\"name\": \"Wirecloud/TestOperatorMissing/1.0\", \"properties\": {}, \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"4\": \"\"}}}, \"username\": {\"secure\": false, \"readonly\": true, \"hidden\": false, \"value\": {\"users\": {\"4\": \"username\"}}}}}, \"2\": {\"name\": \"Wirecloud/TestOperatorSecure/1.0\", \"properties\": {}, \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"4\": \"test_password\"}}}, \"username\": {\"secure\": false, \"readonly\": true, \"hidden\": false, \"value\": {\"users\": {\"4\": \"test_username\"}}}}}}, \"connections\": []}"

--- a/src/wirecloud/fp74caast/fixtures/4caast_test_data.json
+++ b/src/wirecloud/fp74caast/fixtures/4caast_test_data.json
@@ -55,6 +55,7 @@
         "pk": 101,
         "fields": {
             "name": "Workspace",
+            "title": "Workspace",
             "creator": 102,
             "wiringStatus": "{\"operators\": {}, \"connections\": []}"
         }

--- a/src/wirecloud/platform/fixtures/extra_wiring_test_data.json
+++ b/src/wirecloud/platform/fixtures/extra_wiring_test_data.json
@@ -4,6 +4,7 @@
         "pk": 202,
         "fields": {
             "name": "workspaceSecure",
+            "title": "workspaceSecure",
             "public": false,
             "creator": "4",
             "wiringStatus": "{\"operators\": {\"1\": {\"name\": \"Wirecloud/TestOperatorSecure/1.0\", \"properties\": {}, \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"4\": \"\"}}}, \"username\": {\"secure\": false, \"readonly\": true, \"hidden\": false, \"value\": {\"users\": {\"4\": \"username\"}}}}}, \"2\": {\"name\": \"Wirecloud/TestOperatorSecure/1.0\", \"properties\": {}, \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"4\": \"r16Ts7Ekgd4EuYggazdIqQ==\"}}}, \"username\": {\"secure\": false, \"readonly\": true, \"hidden\": false, \"value\": {\"users\": {\"4\": \"test_username\"}}}}}}, \"connections\": []}"

--- a/src/wirecloud/platform/fixtures/selenium_test_data.json
+++ b/src/wirecloud/platform/fixtures/selenium_test_data.json
@@ -23,6 +23,7 @@
         "pk": 1,
         "fields": {
             "name": "ExistingWorkspace",
+            "title": "ExistingWorkspace",
             "creator": 4,
             "description": "This is an <b>example</b> of workspace",
             "longdescription": "This is an **example** of workspace",
@@ -34,6 +35,7 @@
         "pk": 2,
         "fields": {
             "name": "Workspace",
+            "title": "Workspace",
             "creator": 4,
             "wiringStatus": "{\"version\": \"2.0\", \"connections\":[], \"operators\": {}, \"visualdescription\": {\"behaviours\": [], \"components\": {\"operator\": {}, \"widget\": {}}, \"connections\": []}}"
         }
@@ -43,6 +45,7 @@
         "pk": 8,
         "fields": {
             "name": "Workspace",
+            "title": "Workspace",
             "creator": 1,
             "description": "This is an <b>example</b> of workspace",
             "longdescription": "This is an **example** of workspace",
@@ -54,6 +57,7 @@
         "pk": 9,
         "fields": {
             "name": "Workspace",
+            "title": "Workspace",
             "creator": 2,
             "wiringStatus": "{\"version\": \"2.0\", \"connections\":[], \"operators\": {}, \"visualdescription\": {\"behaviours\": [], \"components\": {\"operator\": {}, \"widget\": {}}, \"connections\": []}}"
         }
@@ -63,6 +67,7 @@
         "pk": 10,
         "fields": {
             "name": "SharedWorkspace",
+            "title": "SharedWorkspace",
             "creator": 4,
             "description": "This is an <b>example</b> of workspace",
             "longdescription": "This is an **example** of workspace",
@@ -75,6 +80,7 @@
         "fields": {
             "visible": true,
             "name": "ExistingTab",
+            "title": "ExistingTab",
             "workspace": 1,
             "position": 0
         }
@@ -85,6 +91,7 @@
         "fields": {
             "visible": true,
             "name": "OtherTab",
+            "title": "OtherTab",
             "workspace": 1,
             "position": 1
         }

--- a/src/wirecloud/platform/fixtures/test_data.json
+++ b/src/wirecloud/platform/fixtures/test_data.json
@@ -76,6 +76,7 @@
         "pk": "1",
         "fields": {
             "name": "workspace",
+            "title": "workspace",
             "public": false,
             "creator": "2",
             "wiringStatus": "{\"operators\": {\"1\": {\"name\": \"Wirecloud/TestOperator/1.0\", \"properties\": {}, \"preferences\": {\"pref_with_val\": {\"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"value1\" }}}, \"readonly_pref\": {\"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"value2\"}}}, \"hidden_pref\": {\"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"value3\"}}}, \"empty_pref\": {\"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"value4\"}}}}}, \"2\": {\"name\": \"Wirecloud/TestOperator/1.0\", \"properties\": {}, \"preferences\": {\"pref_with_val\": {\"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"value1\"}}}, \"readonly_pref\": {\"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"value2\"}}}, \"hidden_pref\": {\"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"value3\"}}}, \"empty_pref\": {\"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"\"}}}}}}, \"connections\": []}"
@@ -86,6 +87,7 @@
         "pk": "201",
         "fields": {
             "name": "workspace",
+            "title": "workspace",
             "public": false,
             "creator": "3",
             "wiringStatus": "{\"operators\": {}, \"connections\": []}"
@@ -96,6 +98,7 @@
         "pk": "202",
         "fields": {
             "name": "workspaceSecure",
+            "title": "workspaceSecure",
             "public": false,
             "creator": "2",
             "wiringStatus": "{\"operators\": {\"1\": {\"name\": \"Wirecloud/TestOperatorSecure/1.0\", \"properties\": {}, \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"\"}}}, \"username\": {\"secure\": false, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"username\"}}}}}, \"2\": {\"name\": \"Wirecloud/TestOperatorSecure/1.0\", \"properties\": {}, \"preferences\": {\"pref_secure\": {\"secure\": true, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"r16Ts7Ekgd4EuYggazdIqQ==\"}}}, \"username\": {\"secure\": false, \"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"test_username\"}}}}}}, \"connections\": []}"
@@ -106,6 +109,7 @@
         "pk": "203",
         "fields": {
             "name": "publicworkspace",
+            "title": "publicworkspace",
             "public": true,
             "creator": "2",
             "wiringStatus": "{\"operators\": {\"1\": {\"name\": \"Wirecloud/TestOperator/1.0\", \"properties\": {}, \"preferences\": {\"pref_with_val\": {\"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"value1\" }}}, \"readonly_pref\": {\"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"value2\"}}}, \"hidden_pref\": {\"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"value3\"}}}, \"empty_pref\": {\"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"value4\"}}}}}, \"2\": {\"name\": \"Wirecloud/TestOperator/1.0\", \"properties\": {}, \"preferences\": {\"pref_with_val\": {\"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"value1\"}}}, \"readonly_pref\": {\"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"value2\"}}}, \"hidden_pref\": {\"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"value3\"}}}, \"empty_pref\": {\"readonly\": false, \"hidden\": false, \"value\": {\"users\": {\"2\": \"\"}}}}}}, \"connections\": []}"
@@ -149,6 +153,7 @@
         "fields": {
             "workspace": "1",
             "name": "tab",
+            "title": "tab",
             "visible": true
         }
     },
@@ -158,6 +163,7 @@
         "fields": {
             "workspace": "202",
             "name": "tabSecure",
+            "title": "tabSecure",
             "visible": true
         }
     },

--- a/src/wirecloud/platform/migration_utils.py
+++ b/src/wirecloud/platform/migration_utils.py
@@ -24,6 +24,23 @@ from django.db.migrations.exceptions import IrreversibleError
 import six
 
 
+def workspace_and_tab_title_data_forwards(apps, schema_editor):
+    # Migrate workspace titles
+    workspaces = apps.get_model("platform", "workspace")
+    for workspace in workspaces.objects.all():
+        if workspace.title is None or workspace.title.strip() is "":
+            workspace.title = workspace.name
+            workspace.save()
+            #workspace.title if workspace.title is not None and workspace.title.strip() != "" else workspace.name
+
+    # Migrate tab titles
+    tabs = apps.get_model("platform", "tab")
+    for tab in tabs.objects.all():
+        if tab.title is None or tab.title.strip() is "":
+            tab.title = tab.name
+            tab.save()
+
+
 def mutate_forwards_operator(preference, userID):
     preference["value"] = {"users": {"%s" % userID: preference.get("value", "")}}
     return preference

--- a/src/wirecloud/platform/migrations/0013_workspace_and_tab_title_data.py
+++ b/src/wirecloud/platform/migrations/0013_workspace_and_tab_title_data.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+from wirecloud.platform.migration_utils import workspace_and_tab_title_data_forwards
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('platform', '0012_workspace_and_tab_title'),
+    ]
+
+    operations = [
+        # Copy name into title if title is None or an empty string for both workspaces and tabs
+        migrations.RunPython(workspace_and_tab_title_data_forwards, migrations.RunPython.noop),
+    ]

--- a/src/wirecloud/platform/migrations/0014_workspace_and_tab_title_not_null.py
+++ b/src/wirecloud/platform/migrations/0014_workspace_and_tab_title_not_null.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('platform', '0013_workspace_and_tab_title_data'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='tab',
+            name='title',
+            field=models.CharField(max_length=30, null=False, verbose_name='Title'),
+        ),
+        migrations.AlterField(
+            model_name='workspace',
+            name='title',
+            field=models.CharField(max_length=255, null=False, verbose_name='Title'),
+        ),
+    ]

--- a/src/wirecloud/platform/tests/rest_api.py
+++ b/src/wirecloud/platform/tests/rest_api.py
@@ -1425,6 +1425,7 @@ class ApplicationMashupAPI(WirecloudTestCase, TransactionTestCase):
         def create_workspace_tab():
             data = {
                 'name': 'rest_api_test',
+                'title': 'rest_api_test'
             }
             response = self.client.post(url, json.dumps(data), content_type='application/json; charset=UTF-8', HTTP_ACCEPT='application/json')
             self.assertEqual(response.status_code, 201)

--- a/src/wirecloud/platform/workspace/utils.py
+++ b/src/wirecloud/platform/workspace/utils.py
@@ -334,7 +334,7 @@ def get_workspace_data(workspace, user):
     return {
         'id': "%s" % workspace.id,
         'name': workspace.name,
-        'title': workspace.title if workspace.title is not None and workspace.title.strip() != "" else workspace.name,
+        'title': workspace.title,
         'public': workspace.public,
         'shared': workspace.is_shared(),
         'owner': workspace.creator.username,
@@ -558,7 +558,7 @@ def get_tab_data(tab, workspace=None, cache_manager=None, user=None):
     return {
         'id': "%s" % tab.id,
         'name': tab.name,
-        'title': tab.title if tab.title is not None and tab.title.strip() != "" else tab.name,
+        'title': tab.title,
         'visible': tab.visible,
         'preferences': get_tab_preference_values(tab),
         'iwidgets': [get_iwidget_data(widget, workspace, cache_manager, user) for widget in tab.iwidget_set.order_by('id')]


### PR DESCRIPTION
- Add title migrations for Workspaces and Tabs, so that title cant be null and has by default the value of name
- Add title to all workspaces and tabs fixtures
- Add title handling to 'workspace/utils.py'