### PR TITLE
Create super users in WireCloud if the IDM user has the admin role

### DIFF
--- a/src/wirecloud/fiware/social_auth_backend.py
+++ b/src/wirecloud/fiware/social_auth_backend.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2013-2017 Conwet Lab., Universidad Politécnica de Madrid
+# Copyright (c) 2018 Future Internet Consulting and Development Solutions S.L.
 
 # This file is part of Wirecloud.
 
@@ -113,11 +114,17 @@ class FIWAREOAuth2(BaseOAuth2):
             first_name, last_name = name.split(' ', 1)
         else:
             first_name = name
-        return {'username': response.get('username'),
-                'email': response.get('email') or '',
-                'fullname': name,
-                'first_name': first_name,
-                'last_name': last_name}
+
+        superuser = any(rol['name'].strip().lower() == "admin" for rol in response.get("roles", []))
+        return {
+            'username': response.get('username'),
+            'email': response.get('email') or '',
+            'fullname': name,
+            'first_name': first_name,
+            'last_name': last_name,
+            'is_superuser': superuser,
+            'is_staff': superuser
+        }
 
     def request_user_info(self, access_token):
         response = self.request(url=self.USER_DATA_URL, params={'access_token': access_token})

--- a/src/wirecloud/fiware/tests/social_backend.py
+++ b/src/wirecloud/fiware/tests/social_backend.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2015-2017 Conwet Lab., Universidad Politécnica de Madrid
+# Copyright (c) 2018 Future Internet Consulting and Development Solutions S.L.
 
 # This file is part of Wirecloud.
 
@@ -86,8 +87,9 @@ class TestSocialAuthBackend(WirecloudTestCase, TestCase):
         }]
     }
 
-    USER_DATA = {"username": "demo", "email": "demo@fiware.org", "fullname": "Demo user", "first_name": "Demo", "last_name": "user"}
-    USER_DATA_NO_LAST_NAME = {"username": "demo", "email": "demo@fiware.org", "fullname": "Demo", "first_name": "Demo", "last_name": ""}
+    USER_DATA = {"username": "demo", "email": "demo@fiware.org", "fullname": "Demo user", "first_name": "Demo", "last_name": "user", "is_superuser": False, "is_staff": False}
+    USER_DATA_ADMIN = {"username": "demo", "email": "demo@fiware.org", "fullname": "Demo user", "first_name": "Demo", "last_name": "user", "is_superuser": True, "is_staff": True}
+    USER_DATA_NO_LAST_NAME = {"username": "demo", "email": "demo@fiware.org", "fullname": "Demo", "first_name": "Demo", "last_name": "", "is_superuser": False, "is_staff": False}
 
     def setUp(self):
         self.social_core = MagicMock()
@@ -160,6 +162,14 @@ class TestSocialAuthBackend(WirecloudTestCase, TestCase):
 
         self.assertEqual(data, self.USER_DATA)
 
+    def test_get_user_details_old_version_admin(self):
+
+        response = deepcopy(self.OLD_RESPONSE)
+        response['roles'][0]['name'] = 'admin'
+        data = self.instance.get_user_details(response)
+
+        self.assertEqual(data, self.USER_DATA_ADMIN)
+
     def test_get_user_details_new_version(self):
 
         response = deepcopy(self.NEW_RESPONSE)
@@ -167,6 +177,14 @@ class TestSocialAuthBackend(WirecloudTestCase, TestCase):
         data = self.instance.get_user_details(response)
 
         self.assertEqual(data, self.USER_DATA)
+
+    def test_get_user_details_new_version_admin(self):
+
+        response = deepcopy(self.NEW_RESPONSE)
+        response['roles'][0]['name'] = 'Admin'
+        data = self.instance.get_user_details(response)
+
+        self.assertEqual(data, self.USER_DATA_ADMIN)
 
     def test_get_user_details_no_last_name(self):
 


### PR DESCRIPTION
Create super users in WireCloud if the IDM user has the admin role. This rol should be mapped by name and using a case insensitive matching.