### PR TITLE
Enable coveralls on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ before_script:
 script:
     - src/ci_scripts/travis.sh sqlite3 django$DJANGO_VERSION unittest
 
+after_sucess:
+    - coveralls
+
 branches:
     only:
         - develop


### PR DESCRIPTION
Currently Travis CI is not sending coverage reports to coveralls. This PR enables this.