### PR TITLE
Fix get_absolute_static_url calling get_current_scheme without passing the request parameter

### DIFF
--- a/src/wirecloud/commons/utils/http.py
+++ b/src/wirecloud/commons/utils/http.py
@@ -343,7 +343,7 @@ def get_absolute_reverse_url(viewname, request=None, **kwargs):
 def get_absolute_static_url(url, request=None, versioned=False):
     from django.conf import settings
 
-    scheme = get_current_scheme()
+    scheme = get_current_scheme(request)
     base = urljoin(scheme + '://' + get_current_domain(request), settings.STATIC_URL)
 
     if versioned:


### PR DESCRIPTION
Current implementation of the `get_absolute_static_url` is calling get_current_scheme without using the request parameter. This parameter is required to be able to detect if the server is running on http or https if `FORCE_PROTO` is not used, so this method creates incorrect urls on those cases. This PR fixes this and add unit tests for the `get_absolute_static_url` method.