### PR TITLE
Prepare documentation for 1.2 release

### DIFF
--- a/docs/administration_guide.md
+++ b/docs/administration_guide.md
@@ -164,7 +164,7 @@ You can restore the backup using the following command:
 
         $ python manage.py migrate
         $ python manage.py populate
-        $ python manage.py resetsearchindexes
+        $ python manage.py rebuild_index
         $ python manage.py collectstatic --noinput
 
     > **NOTE**: Remember to run those commands using the user serving wirecloud
@@ -183,6 +183,16 @@ $ wirecloud-admin --version
 
 > **NOTE:** It is strongly recommended to perform a full database backup before
 > starting to migrate WireCloud to a new version.
+
+
+## From 1.1.x to 1.2.x
+
+WireCloud 1.2 has moved from directly use Whoosh for using search indexes to use
+Haystack for managing search indexes. Although Haystack has support for using
+Whoosh as search index backend, the schema used for the search indexes are
+different. You have to incorporate Haystack configuration into your
+`settings.py` file and rebuild them by running the `rebuild_index` command.
+
 
 ## From 1.0.x to 1.1.x
 

--- a/docs/development/platform/themes.md
+++ b/docs/development/platform/themes.md
@@ -179,7 +179,7 @@ sections.
 
 
 [Compass]: http://compass-style.org/help/tutorials/integration/
-[Django's admin app]: https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#admin-overriding-templates
+[Django's admin app]: https://docs.djangoproject.com/en/1.11/ref/contrib/admin/#admin-overriding-templates
 [Django's staticfiles app]: https://docs.djangoproject.com/en/1.6/ref/contrib/staticfiles/
 
 

--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-This Installation WireCloud version 1.1 (starting from FIWARE release 6.1). Any
+This Installation WireCloud version 1.2 (starting from FIWARE release 7.4). Any
 feedback on this document is highly welcomed, including bugs, typos or things
 you think should be included but are not. Please send it to the "Contact Person"
 email that appears in the [Catalogue page for this GEi][catalogue].
@@ -320,7 +320,7 @@ the [database engines supported by Django].
 
 The following examples show you how to configure SQLite and PostgreSQL databases.
 
-[database engines supported by Django]: https://docs.djangoproject.com/en/1.8/ref/settings/#databases
+[database engines supported by Django]: https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
 
 ### SQLite
@@ -650,7 +650,7 @@ FIWARE_PORTALS = (
 Set `FORCE_DOMAIN` using an string if you want to force WireCloud to use a
 concrete domain name (without including the port) when building internal URLs.
 If this setting is `None` (the default), WireCloud will try to use the [Django's
-sites framework](https://docs.djangoproject.com/en/1.8/ref/contrib/sites/) for
+sites framework](https://docs.djangoproject.com/en/1.11/ref/contrib/sites/) for
 obtaining the domain info. If the sites framework is not used, the domain is
 extracted from the request.
 
@@ -710,9 +710,9 @@ errors to an email log handler when `DEBUG` is `False`.
 
 You can see the default logging configuration by looking in
 wirecloud/commons/utils/conf.py (or view the [online
-source](https://github.com/Wirecloud/wirecloud/blob/1.0.x/src/wirecloud/commons/utils/conf.py)).
+source](https://github.com/Wirecloud/wirecloud/blob/1.2.x/src/wirecloud/commons/utils/conf.py)).
 
-[LOGGING_CONFIG]: https://docs.djangoproject.com/es/1.8/ref/settings/#logging-config
+[LOGGING_CONFIG]: https://docs.djangoproject.com/es/1.11/ref/settings/#logging-config
 
 
 ### SERVER_EMAIL
@@ -740,7 +740,7 @@ themes](development/platform/themes).
 
 A data structure containing the middleware configuration per URL group where the URL group name are the keys of the dictionary and the value should be a tuple of middleware classes to use for that group.
 
-You should use this setting as replacement of the Django's MIDDLEWARE_CLASSES setting (See [Django's middleware documentation](https://docs.djangoproject.com/en/1.8/topics/http/middleware/))
+You should use this setting as replacement of the Django's MIDDLEWARE_CLASSES setting (See [Django's middleware documentation](https://docs.djangoproject.com/en/1.11/topics/http/middleware/))
 
 Currently available groups are "default", "api" and "proxy". For example, if you want to add a middleware class to the "api" group, you can use the following code:
 

--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -17,7 +17,7 @@ step, as they will be installed throughout the documentation:**
 - A Database Manager (MySQL, PostgreSQL, SQLite3...)
 - Python 2.7 or python 3.4+. In any case, the following python packages must be
   installed:
-    - Django 1.8-1.11
+    - Django 1.9-1.11
     - lxml 2.3.0+
     - django-appconf 1.0.1+
     - django_compressor 2.0+
@@ -356,7 +356,7 @@ For production purposes, PostgreSQL database is a much better choice. To do so, 
 ```python
 DATABASES = {
       'default': {
-             'ENGINE': 'django.db.backends.postgresql_psycopg2',
+             'ENGINE': 'django.db.backends.postgresql',
              'NAME': '${dbname}',
              'USER': '${dbuser}',
              'PASSWORD': '${dbpassword}',

--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -849,9 +849,10 @@ On the WireCloud instance:
         ```python
         AUTHENTICATION_BACKENDS = (
             'wirecloud.fiware.social_auth_backend.FIWAREOAuth2',
-            'django.contrib.auth.backends.ModelBackend',
         )
         ```
+
+        > **Note**: Django supports several authentication backends (see this [link](https://docs.djangoproject.com/en/1.11/topics/auth/customizing/#specifying-authentication-backends) for more details). For example, you can continue authenticating users using the local db by also listing `django.contrib.auth.backends.ModelBackend` in `AUTHENTICATION_BACKENDS`, although this will require extra configuration not documented in this guide.
 
     - Add a `FIWARE_IDM_SERVER` setting pointing to the IdM server to use (e.g. `FIWARE_IDM_SERVER = "https://account.lab.fiware.org"`)
     - Add `SOCIAL_AUTH_FIWARE_KEY` and `SOCIAL_AUTH_FIWARE_SECRET` settings using the *Client ID* and the *Client Secret* values provided by the IdM. You should end having something like this:

--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -447,29 +447,54 @@ $ python manage.py populate
 
 ## Search indexes configuration
 
-Wirecloud uses Haystack to handle the search indexes.
+Wirecloud uses [Haystack](http://haystacksearch.org/) to handle the search
+indexes.
 
-Currently, Solr, ElasticSearch2 and Whoosh are supported. Whoosh is enabled by default.
+Currently, [Solr][], [ElasticSearch2][] and [Whoosh][] are supported. Whoosh is enabled by
+default.
 
-To modify the search engine configuration, it is necessary to modify the `HAYSTACK_CONNECTIONS`
-configuration setting in the instance `settings.py` file (e.g.
-`/opt/wirecloud_instance/wirecloud_instance/settings.py`).
+To modify the search engine configuration, it is necessary to modify the
+`HAYSTACK_CONNECTIONS` configuration setting in the instance `settings.py` file
+(e.g. `/opt/wirecloud_instance/wirecloud_instance/settings.py`).
 
+[Solr]: http://lucene.apache.org/solr/
+[ElasticSearch2]: https://www.elastic.co/products/elasticsearch
+[Whoosh]: https://whoosh.readthedocs.io/en/latest/
 
 ### Whoosh configuration
+
+[Whoosh][] is a fast, featureful full-text indexing and searching library
+implemented in pure Python. It is very easy to configure and does not require to
+configure any service, so it is ideal for basic installations. This make this
+engine the default engine for using WireCloud, altough probably ElasticSearch2
+or Solr are better choices if you require to provide an high availablility
+installation of WireCloud.
+
+This is the default configuration:
 
 ```python
 HAYSTACK_CONNECTIONS = {
     'default': {
         'ENGINE': 'wirecloud.commons.haystack_backends.whoosh_backend.WhooshEngine',
-        'PATH': path.join(path.dirname(__file__), 'whoosh_index'),
+        'PATH': path.join(BASEDIR, 'index'),
     },
 }
 ```
 
-Where `PATH` is the location where Whoosh will store the indexes.
+You can add the `HAYSTACK_CONNECTIONS` setting in the `settings.py` file to
+change the `PATH` where Whoosh indices will be stored.
+
 
 ### ElasticSearch2 configuration
+
+[ElasticSearch][] support is not installed by default, so the first thing is to
+install the python module required to connect to ElasticSearch:
+
+```
+$ pip install elasticsearch==2.4.1
+```
+
+Next step is to configure haystack to use ElasticSearch:
 
 ```python
 HAYSTACK_CONNECTIONS = {
@@ -483,24 +508,16 @@ HAYSTACK_CONNECTIONS = {
 
 Where `URL` is the URL of the ElasticSearch2 server.
 
-The only thing that remains is installing the python library for ElasticSearch:
-
-    $ pip install elasticsearch==2.4.1
-
-and configuring the `URL` parameter to point to the ElasticSearch2 server.
-
 
 ### Solr cofiguration
 
-Before being able to use Solr, you should install `pysolr`:
+Solr support is not installed by default, so the first thing is to install the python library required to connect to Solr:
 
 ```
 $ pip install pysolr
 ```
 
-Once you have Solr 6.x deployed, you have to create and configure a new Solr core to be used from WireCloud. The Solr core can be created by running the following commannd: `bin/solr create -c wirecloud_core -n basic_config` on the Solr installation, where `wirecloud_core` is the core name. Then you have to execute the `python manage.py build_solr_schema` command jointly with the `--configure-directory` option on the WireCloud installation. Ideally, you should use the `--configure-directory` to point into the configuration folder (e.g. to `${SOLR_ROOT}/server/solr/wirecloud_core/conf`) of the Solr core, so it gets configured automatically. But if this is not possible (because the folder is in a remote server), you should point it into a temporal folder and copy the generated files (`schema.xml` and `solrconfig.xml`) to the final destination. You should also ensure the configuration folder does not contain a `managed-schema.xml` file, as this file is created by default but should not be used when using the WireCloud schema.
-
-Now you can change the Haystack configuration to point to the Solr server. This is an example:
+Once installed `pysolr`, you have to change the Haystack configuration:
 
 ```python
 HAYSTACK_CONNECTIONS = {
@@ -513,6 +530,14 @@ HAYSTACK_CONNECTIONS = {
 ```
 
 Where the `URL` setting should point to the Solr core URL.
+
+Haystack provides a command for generating the solr schema (needed to create the
+solr core), but requires you to configure haystack to use the rSsolr engine before
+running that command. You can provide and invalid URL (e.g. an empty string:
+`''`) and change this configuration once you have created the core in the
+Solr server.
+
+The Solr core can be created by running the following commannd: `bin/solr create -c wirecloud_core -n basic_config` on the Solr installation, where `wirecloud_core` is the core name. Then you have to execute the `python manage.py build_solr_schema` command jointly with the `--configure-directory` option on the WireCloud installation. Ideally, you should use the `--configure-directory` to point into the configuration folder (e.g. to `${SOLR_ROOT}/server/solr/wirecloud_core/conf`) of the Solr core, so it gets configured automatically. But if this is not possible (because the folder is in a remote server), you should point it into a temporal folder and copy the generated files (`schema.xml` and `solrconfig.xml`) to the final destination. You should also ensure the configuration folder does not contain a `managed-schema.xml` file, as this file is created by default and conflicts with the configuration created by Haystack.
 
 
 ## Extra options

--- a/docs/slides/3.1.8_Accessing_third-party_servicies_using_IdM_tokens.md
+++ b/docs/slides/3.1.8_Accessing_third-party_servicies_using_IdM_tokens.md
@@ -164,24 +164,6 @@ MashupPlatform.http.makeRequest(url, {
 
 ---
 
-## Deprecated header names
-
-Version 0.9.0 and below of WireCloud uses another set of the header names.
-They were prefixed with `X-` and had a dash inside the FIWARE word. For example,
-`FIWARE-OAuth-Token` was named `X-FI-WARE-OAuth-Token`. In addition, the header
-for indicating the body pattern was further restructured. 
-
-| WireCloud 0.9.1+           | WireCloud 0.9.0 and bellow         |
-|----------------------------|------------------------------------|
-| FIWARE-OAuth-Body-Pattern  | X-FI-WARE-OAuth-Token-Body-Pattern |
-| FIWARE-OAuth-GET-Parameter | X-FI-WARE-OAuth-GET-Parameter      |
-| FIWARE-OAuth-Header-Name   | X-FI-WARE-OAuth-Header-Name        |
-| FIWARE-OAuth-Source        | X-FI-WARE-OAuth-Source             |
-
-Old names can still be used but will be removed in WireCloud 1.1
-
----
-
 .fx: back-cover
 
 Thanks!

--- a/src/settings.py
+++ b/src/settings.py
@@ -21,7 +21,7 @@ MANAGERS = ADMINS
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',      # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
+        'ENGINE': 'django.db.backends.sqlite3',      # Add 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
         'NAME': path.join(BASEDIR, 'wirecloud.db'),  # Or path to database file if using sqlite3.
         'USER': '',                                  # Not used with sqlite3.
         'PASSWORD': '',                              # Not used with sqlite3.

--- a/src/wirecloud/catalogue/locale/es/LC_MESSAGES/django.po
+++ b/src/wirecloud/catalogue/locale/es/LC_MESSAGES/django.po
@@ -2,14 +2,15 @@
 # Copyright (C) 2015-2016 CoNWeT Lab., Universidad Politécnica de Madrid
 # This file is distributed under the same license as the WireCloud package.
 # Álvaro Arranz García <aarranz@fi.upm.es>, 2015-2016.
+# Álvaro Arranz García <aarranz@ficodes.com>, 2018.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: WireCloud 1.0\n"
+"Project-Id-Version: WireCloud 1.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-23 10:46+0200\n"
+"POT-Creation-Date: 2018-10-24 12:25+0200\n"
 "PO-Revision-Date: 2016-09-15 15:25+0200\n"
-"Last-Translator: Álvaro Arranz García <aarranz@fi.upm.es>\n"
+"Last-Translator: Álvaro Arranz García <aarranz@ficodes.com>\n"
 "Language-Team: Español/España\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -43,43 +44,43 @@ msgstr ""
 "Fallo la importación del componente de aplicación mashable desde "
 "%(file_name)s"
 
-#: models.py:53
+#: models.py:47
 msgid "Vendor"
 msgstr "Distribuidor"
 
-#: models.py:54
+#: models.py:48
 msgid "Name"
 msgstr "Nombre"
 
-#: models.py:55
+#: models.py:49
 msgid "Version"
 msgstr "Versión"
 
-#: models.py:56
+#: models.py:50
 msgid "Type"
 msgstr "Tipo"
 
-#: models.py:60
+#: models.py:54
 msgid "Available to all users"
 msgstr "Disponible para todos los usuarios"
 
-#: models.py:61
+#: models.py:55
 msgid "Users"
 msgstr "Usuarios"
 
-#: models.py:62
+#: models.py:56
 msgid "Groups"
 msgstr "Grupos"
 
-#: models.py:65
+#: models.py:59
 msgid "templateURI"
 msgstr "templateURI"
 
-#: models.py:67
+#: models.py:61
 msgid "popularity"
 msgstr "popularidad"
 
-#: models.py:69
+#: models.py:63
 msgid "JSON description"
 msgstr "Descripción en JSON"
 
@@ -106,7 +107,7 @@ msgstr ""
 "El fichero %(file_name)s no está codificado usando el conjunto de caracteres "
 "indicado (%(charset)s según el fichero de descripción del widget)."
 
-#: views.py:87 views.py:242
+#: views.py:87 views.py:222
 msgid "Missing parameter: template_uri or file"
 msgstr "Faltan el parámetro template_uri o file"
 
@@ -114,49 +115,40 @@ msgstr "Faltan el parámetro template_uri o file"
 msgid "Resource already exists"
 msgstr "Ya existe el recurso"
 
-#: views.py:113
+#: views.py:114
 #, python-format
 msgid "Invalid pagenum value: %s"
 msgstr "Valor inválido para pagenum: %s"
 
-#: views.py:119
+#: views.py:120
 #, python-format
 msgid "Invalid maxresults value: %s"
 msgstr "Valor inválido para maxresults: %s"
 
-#: views.py:123
+#: views.py:124
 #, python-format
 msgid "Orderby value not supported: %s"
 msgstr "Valor para el parámetro orderby no soportado: %s"
 
-#: views.py:129
+#: views.py:132
 #, python-format
 msgid "Scope value not supported: %s"
 msgstr "Valor para el parámetro scope no soportado: %s"
 
-#: views.py:132
+#: views.py:135
 msgid "Forbidden"
 msgstr "Prohibido"
 
-#: views.py:167
+#: views.py:170
 #, python-format
 msgid "user %(username)s is not the owner of the resource %(resource_id)s"
 msgstr "el usuario %(username)s no es el dueño del recurso %(resource_id)s"
 
-#: views.py:198
-msgid "Invalid prefix value (it cannot contain spaces)"
-msgstr "Valor inválido para el parámetro limit (no puede contener espacios)"
-
-#: views.py:205
-msgid "Invalid limit value (it must be positive integer)"
-msgstr ""
-"Valor inválido para el parámetro limit (tiene que ser un entero positivo)"
-
-#: views.py:262
+#: views.py:242
 msgid "Error opening the changelog file"
 msgstr "Error abriendo el fichero de registro de cambios"
 
-#: views.py:288
+#: views.py:268
 #, python-format
 msgid ""
 "You can find the userguide of this component in this external <a target="
@@ -165,6 +157,6 @@ msgstr ""
 "Puedes encontrar la documentación de este recurso in este <a target=\"_blank"
 "\" href=\"%s\">enlace externo</a>"
 
-#: views.py:304
+#: views.py:284
 msgid "Error opening the userguide file"
 msgstr "Error abriendo el fichero de la guía de usuario"

--- a/src/wirecloud/catalogue/locale/es/LC_MESSAGES/djangojs.po
+++ b/src/wirecloud/catalogue/locale/es/LC_MESSAGES/djangojs.po
@@ -2,14 +2,15 @@
 # Copyright (C) 2015-2016 CoNWeT Lab., Universidad Politécnica de Madrid
 # This file is distributed under the same license as the WireCloud package.
 # Álvaro Arranz García <aarranz@fi.upm.es>, 2015-2016.
+# Álvaro Arranz García <aarranz@ficodes.com>, 2018.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: WireCloud 1.0\n"
+"Project-Id-Version: WireCloud 1.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-23 10:46+0200\n"
+"POT-Creation-Date: 2018-10-24 12:44+0200\n"
 "PO-Revision-Date: 2016-09-21 01:34+0200\n"
-"Last-Translator: Álvaro Arranz García <aarranz@fi.upm.es>\n"
+"Last-Translator: Álvaro Arranz García <aarranz@ficodes.com>\n"
 "Language-Team: Español/España\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -18,32 +19,28 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.9\n"
 
-#: static/js/wirecloud/WirecloudCatalogue.js:120
-#: static/js/wirecloud/WirecloudCatalogue.js:244
+#: static/js/wirecloud/WirecloudCatalogue.js:129
+#: static/js/wirecloud/WirecloudCatalogue.js:241
 msgid "Unexpected response from server"
 msgstr "Respuesta inesperada del servidor"
 
-#: static/js/wirecloud/WirecloudCatalogue.js:136
+#: static/js/wirecloud/WirecloudCatalogue.js:144
 msgid "Doing catalogue search"
 msgstr "Buscando en el servidor"
 
-#: static/js/wirecloud/WirecloudCatalogue.js:182
-msgid "market_endpoint option can only be used on local catalogues"
-msgstr "la opción market_endpoint solo se puede usar en el catálogo local"
-
-#: static/js/wirecloud/WirecloudCatalogue.js:201
+#: static/js/wirecloud/WirecloudCatalogue.js:198
 msgid "Uploading packaged component %(filename)s"
 msgstr "Subiendo el componente empaquetado %(filename)s"
 
-#: static/js/wirecloud/WirecloudCatalogue.js:221
+#: static/js/wirecloud/WirecloudCatalogue.js:218
 msgid "Installing component from %(url)s"
 msgstr "Instalando componente desde %(url)s"
 
-#: static/js/wirecloud/WirecloudCatalogue.js:270
+#: static/js/wirecloud/WirecloudCatalogue.js:267
 msgid "Deleting all versions of %(title)s (%(group_id)s)"
 msgstr "Eliminando todas las versiones de %(title)s (%(group_id)s)"
 
-#: static/js/wirecloud/WirecloudCatalogue.js:277
+#: static/js/wirecloud/WirecloudCatalogue.js:274
 msgid "Deleting %(title)s (%(uri)s)"
 msgstr "Borrando %(title)s (%(uri)s)"
 

--- a/src/wirecloud/catalogue/static/js/wirecloud/WirecloudCatalogue.js
+++ b/src/wirecloud/catalogue/static/js/wirecloud/WirecloudCatalogue.js
@@ -173,9 +173,9 @@
         }, options);
 
         if (this.name !== 'local' && options.market_endpoint != null) {
-            throw new TypeError(utils.gettext("market_endpoint option can only be used on local catalogues"));
+            throw new TypeError("market_endpoint option can only be used on local catalogues");
         } else if (options.market_endpoint == null && options.file == null && options.url == null) {
-            throw new TypeError(utils.gettext("at least one of the following options has to be used: file or market_endpoint"));
+            throw new TypeError("at least one of the following options has to be used: file or market_endpoint");
         }
 
         requestHeaders = {

--- a/src/wirecloud/commons/conf/catalogue_project_template/project_name/settings.py
+++ b/src/wirecloud/commons/conf/catalogue_project_template/project_name/settings.py
@@ -19,7 +19,7 @@ MANAGERS = ADMINS
 
 DATABASES = {
     'default': {
-        'ENGINE': {{ db_engine }},       # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
+        'ENGINE': {{ db_engine }},       # Add 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
         'NAME': {{ db_name }},           # Or path to database file if using sqlite3.
         # The following settings are not used with sqlite3:
         'USER': '',

--- a/src/wirecloud/commons/conf/platform_project_template/project_name/settings.py
+++ b/src/wirecloud/commons/conf/platform_project_template/project_name/settings.py
@@ -19,7 +19,7 @@ MANAGERS = ADMINS
 
 DATABASES = {
     'default': {
-        'ENGINE': {{ db_engine }},       # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
+        'ENGINE': {{ db_engine }},       # Add 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
         'NAME': {{ db_name }},           # Or path to database file if using sqlite3.
         # The following settings are not used with sqlite3:
         'USER': '',

--- a/src/wirecloud/commons/locale/es/LC_MESSAGES/django.po
+++ b/src/wirecloud/commons/locale/es/LC_MESSAGES/django.po
@@ -2,78 +2,39 @@
 # Copyright (C) 2015-2016 CoNWeT Lab., Universidad Politécnica de Madrid
 # This file is distributed under the same license as the WireCloud package.
 # Álvaro Arranz García <aarranz@fi.upm.es>, 2015-2016.
+# Álvaro Arranz García <aarranz@ficodes.com>, 2018.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: WireCloud 1.0\n"
+"Project-Id-Version: WireCloud 1.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-23 10:58+0200\n"
-"PO-Revision-Date: 2016-09-21 01:36+0200\n"
-"Last-Translator: Álvaro Arranz García <aarranz@fi.upm.es>\n"
+"POT-Creation-Date: 2018-10-24 12:45+0200\n"
+"PO-Revision-Date: 2018-10-24 12:47+0200\n"
+"Last-Translator: Álvaro Arranz García <aarranz@ficodes.com>\n"
 "Language-Team: Español/España\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 1.8.9\n"
+"X-Generator: Poedit 2.2\n"
 
 #: authentication.py:39
 msgid "Logged out"
 msgstr "Sesión cerrada"
 
-#: management/commands/resetsearchindexes.py:41
+#: management/commands/createorganization.py:35
 #, python-format
-msgid "Reseting \"%s\" index"
-msgstr "Reconstruyendo el índice \"%s\""
+msgid "Organization \"%s\" created successfully"
+msgstr "La organización “%s” ha sido creada correctamente"
 
-#: management/commands/resetsearchindexes.py:42
-#, python-format
-msgid "The \"%s\" index was updated successfully"
-msgstr "El índice \"%s\" ha sido actualizado correctamente"
+#: management/commands/createorganization.py:50
+msgid "Orgranization Name is already taken."
+msgstr "Nombre de organización ya en uso"
 
-#: management/commands/resetsearchindexes.py:43
-#, python-format
-msgid "The following indexes are not available: %s"
-msgstr "Los siguientes índices no están disponibles: %s"
-
-#: management/commands/resetsearchindexes.py:81
-#, python-format
-msgid ""
-"You have requested to reset indexes found in the location\n"
-"specified in your settings:\n"
-"\n"
-"    %s\n"
-"\n"
-msgstr ""
-"Estas pidiendo reconstruir los indices de búsqueda disponibles\n"
-"disponibles en la carpeta indicada en la configuración:\n"
-"\n"
-"  %s\n"
-"\n"
-
-#: management/commands/resetsearchindexes.py:85
-msgid "This will DELETE EXISTING FILES!\n"
-msgstr "Esta acción BORRARÁ LOS FICHEROS ACTUALES!\n"
-
-#: management/commands/resetsearchindexes.py:87
-msgid ""
-"Are you sure you want to do this?\n"
-"\n"
-"Type 'yes' to continue, or 'no' to cancel: "
-msgstr ""
-"Estas seguro de que quieres continuar?\n"
-"\n"
-"Escribe ‘yes’ para continuar o ‘no’ para cancelar: "
-
-#: management/commands/resetsearchindexes.py:92
-msgid "Reset search indexes cancelled."
-msgstr "Se ha cancelado el reinicio de los indices de búsqueda."
-
-#: management/commands/resetsearchindexes.py:105
-#, python-format
-msgid "Adding %s\n"
-msgstr "Añadiendo %s\n"
+#: management/commands/resetsearchindexes.py:44
+msgid "The indexes argument is not supported anymore."
+msgstr "El argumento indexes ya no está soportado."
 
 #: middleware.py:151 middleware.py:160
 msgid "Bad credentials"
@@ -262,6 +223,6 @@ msgstr "Valor inválido para pagenum: %s"
 msgid "Invalid maxresults value: %s"
 msgstr "Valor inválido para maxresults: %s"
 
-#: views.py:99
+#: views.py:103
 msgid "You don't have permission to switch current session user"
 msgstr "No tienes permisos para cambiar el usuario de la sesión actual"

--- a/src/wirecloud/commons/locale/es/LC_MESSAGES/djangojs.po
+++ b/src/wirecloud/commons/locale/es/LC_MESSAGES/djangojs.po
@@ -2,21 +2,22 @@
 # Copyright (C) 2015-2016 CoNWeT Lab., Universidad Politécnica de Madrid
 # This file is distributed under the same license as the WireCloud package.
 # Álvaro Arranz García <aarranz@fi.upm.es>, 2015-2016.
+# Álvaro Arranz García <aarranz@ficodes.com>, 2018.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: WireCloud 1.0\n"
+"Project-Id-Version: WireCloud 1.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-23 10:58+0200\n"
-"PO-Revision-Date: 2016-01-15 11:48+0100\n"
-"Last-Translator: Álvaro Arranz García <aarranz@fi.upm.es>\n"
+"POT-Creation-Date: 2018-10-24 12:49+0200\n"
+"PO-Revision-Date: 2018-10-24 12:55+0200\n"
+"Last-Translator: Álvaro Arranz García <aarranz@ficodes.com>\n"
 "Language-Team: Español/España\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 1.8.6\n"
+"X-Generator: Poedit 2.2\n"
 
 #: static/js/StyledElements/FileField.js:107
 #: static/js/wirecloud/ui/MACSelectionWindowMenu.js:35
@@ -32,6 +33,7 @@ msgid "Reset"
 msgstr "Reiniciar"
 
 #: static/js/StyledElements/Form.js:94
+#: static/js/wirecloud/ui/MessageWindowMenu.js:43
 msgid "Accept"
 msgstr "Aceptar"
 
@@ -79,8 +81,8 @@ msgstr "Ordenar por %(column_name)s"
 msgid "No data available"
 msgstr "No hay datos disponibles"
 
-#: static/js/StyledElements/Notebook.js:107
-#: static/js/StyledElements/Notebook.js:110
+#: static/js/StyledElements/Notebook.js:108
+#: static/js/StyledElements/Notebook.js:111
 msgid "Add Tab"
 msgstr "Añadir pestaña"
 
@@ -90,8 +92,8 @@ msgid ""
 "\">Page: <t:currentPage/>/<t:totalPages/></div><t:nextBtn/><t:lastBtn/></div>"
 msgstr ""
 "<div class=\"se-input-group\"><t:firstBtn/><t:prevBtn/><div class=\"se-box"
-"\">Página: <t:currentPage/>/<t:totalPages/></div><t:nextBtn/><t:lastBtn/>"
-"</s:styledgui>"
+"\">Página: <t:currentPage/>/<t:totalPages/></div><t:nextBtn/><t:lastBtn/></s:"
+"styledgui>"
 
 #: static/js/StyledElements/Typeahead.js:174
 msgid "No results found for <em><t:query/></em>"
@@ -100,6 +102,19 @@ msgstr "No se han encontrado resultados para <em><t:query/></em>"
 #: static/js/StyledElements/Utils.js:511
 msgid "N/A"
 msgstr "N/A"
+
+#: static/js/wirecloud/ui/AlertWindowMenu.js:50
+msgid "Yes"
+msgstr "Sí"
+
+#: static/js/wirecloud/ui/AlertWindowMenu.js:51
+msgid "No"
+msgstr "No"
+
+#: static/js/wirecloud/ui/AlertWindowMenu.js:59
+#: static/js/wirecloud/ui/MessageWindowMenu.js:29
+msgid "Warning"
+msgstr "Atención"
 
 #: static/js/wirecloud/ui/ExternalProcessWindowMenu.js:93
 msgid "Start"
@@ -120,19 +135,19 @@ msgstr "Borrar la seleccion actual"
 msgid "Search"
 msgstr "Buscar"
 
-#: static/js/wirecloud/ui/MACSearch.js:58
+#: static/js/wirecloud/ui/MACSearch.js:64
 msgid "Keywords..."
-msgstr "Texto de búsqueda"
+msgstr "Texto de búsqueda…"
 
-#: static/js/wirecloud/ui/MACSearch.js:134
+#: static/js/wirecloud/ui/MACSearch.js:157
 msgid "Connection error: No resource retrieved"
 msgstr "Problema de conexión: No se ha recibido ningún recurso"
 
-#: static/js/wirecloud/ui/MACSearch.js:204
+#: static/js/wirecloud/ui/MACSearch.js:227
 msgid "<p>Showing results for <b><t:corrected_query/></b></p>"
 msgstr "<p>Mostrando los resultados para <b><t:corrected_query/></b></p>"
 
-#: static/js/wirecloud/ui/MACSearch.js:221
+#: static/js/wirecloud/ui/MACSearch.js:244
 msgid ""
 "<p>We couldn't find anything for your search - <b>%(keywords)s.</b></"
 "p><p>Suggestions:</p><ul><li>Make sure all words are spelled correctly.</"
@@ -143,7 +158,7 @@ msgstr ""
 "palabras estén escritas correctamente.</li><li>Prueba con otras palabras "
 "clave.</li><li>Inténtalo con palabras clave más generales.</li></ul>"
 
-#: static/js/wirecloud/ui/MACSearch.js:224
+#: static/js/wirecloud/ui/MACSearch.js:247
 msgid ""
 "<p>Currently, you do not have access to any %(scope)s component. You can get "
 "components using the Marketplace view or by uploading components manually "
@@ -154,7 +169,7 @@ msgstr ""
 "recursos de forma manual usando el botón Subir en la vista de Mis Recursos.</"
 "p>"
 
-#: static/js/wirecloud/ui/MACSearch.js:227
+#: static/js/wirecloud/ui/MACSearch.js:250
 msgid ""
 "<p>Currently, you do not have access to any component. You can get "
 "components using the Marketplace view or by uploading components manually "
@@ -163,6 +178,14 @@ msgstr ""
 "<p>Actualmente no tienes acceso a ningún componente. Puedes obtener "
 "componentes usando la vista de Marketplace o subiendo recursos de forma "
 "manual usando el botón Subir en la vista de Mis Recursos.</p>"
+
+#: static/js/wirecloud/ui/MessageWindowMenu.js:29
+msgid "Error"
+msgstr "Error"
+
+#: static/js/wirecloud/ui/MessageWindowMenu.js:29
+msgid "Info"
+msgstr "Detalles"
 
 #: static/js/wirecloud/ui/Tutorial/SimpleDescription.js:83
 msgid "Next"

--- a/src/wirecloud/defaulttheme/locale/es/LC_MESSAGES/django.po
+++ b/src/wirecloud/defaulttheme/locale/es/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: WireCloud 1.0\n"
+"Project-Id-Version: WireCloud 1.2\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-10-23 11:10+0200\n"
 "PO-Revision-Date: 2016-09-21 01:42+0200\n"

--- a/src/wirecloud/fiware/__init__.py
+++ b/src/wirecloud/fiware/__init__.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Wirecloud.  If not, see <http://www.gnu.org/licenses/>.
 
-__version_info__ = (6, 4, 1)
+__version_info__ = (7, 4, 1)
 __version__ = '.'.join(map(str, __version_info__))
 
 FIWARE_LAB_PORTALS = (

--- a/src/wirecloud/fiware/locale/es/LC_MESSAGES/django.po
+++ b/src/wirecloud/fiware/locale/es/LC_MESSAGES/django.po
@@ -2,14 +2,15 @@
 # Copyright (C) 2015-2016 CoNWeT Lab., Universidad Politécnica de Madrid
 # This file is distributed under the same license as the WireCloud package.
 # Álvaro Arranz García <aarranz@fi.upm.es>, 2015-2016.
+# Álvaro Arranz García <aarranz@ficodes.com>, 2018.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: WireCloud 1.0\n"
+"Project-Id-Version: WireCloud 1.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-23 11:22+0200\n"
+"POT-Creation-Date: 2018-10-24 12:56+0200\n"
 "PO-Revision-Date: 2016-03-31 13:09+0200\n"
-"Last-Translator: Álvaro Arranz García <aarranz@fi.upm.es>\n"
+"Last-Translator: Álvaro Arranz García <aarranz@ficodes.com>\n"
 "Language-Team: Español/España\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -18,32 +19,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.7\n"
 
-#: marketAdaptor/usdlParser.py:77
-msgid "Error the document has not a valid rdf format"
-msgstr "Error - El documento no tiene un formato RDF válido"
-
-#: marketAdaptor/usdlParser.py:83
-#, python-format
-msgid "Error parsing rdf document: %s"
-msgstr "Error pareando el documento RDF: %s"
-
-#: marketAdaptor/usdlParser.py:92
-msgid "Error the document is not a valid usdl document"
-msgstr "Error - el documento no es un documento USDL válido"
-
-#: plugins.py:250
+#: plugins.py:129
 msgid "FIWARE version"
 msgstr "Versión de FIWARE"
 
-#: plugins.py:251
+#: plugins.py:130
 msgid "FIWARE version of the platform"
 msgstr "La versión de FIWARE de la plataforma"
 
-#: plugins.py:254
+#: plugins.py:133
 msgid "FIWARE token available"
 msgstr "Token de FIWARE disponible"
 
-#: plugins.py:255
+#: plugins.py:134
 msgid ""
 "Indicates if the current user has associated a FIWARE auth token that can be "
 "used for accessing other FIWARE resources"

--- a/src/wirecloud/fiware/locale/es/LC_MESSAGES/djangojs.po
+++ b/src/wirecloud/fiware/locale/es/LC_MESSAGES/djangojs.po
@@ -2,14 +2,15 @@
 # Copyright (C) 2015-2016 CoNWeT Lab., Universidad Politécnica de Madrid
 # This file is distributed under the same license as the WireCloud package.
 # Álvaro Arranz García <aarranz@fi.upm.es>, 2015-2016.
+# Álvaro Arranz García <aarranz@ficodes.com>, 2015-2016.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: WireCloud 1.0\n"
+"Project-Id-Version: WireCloud 1.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-23 11:22+0200\n"
+"POT-Creation-Date: 2018-10-24 12:56+0200\n"
 "PO-Revision-Date: 2016-09-21 01:45+0200\n"
-"Last-Translator: Álvaro Arranz García <aarranz@fi.upm.es>\n"
+"Last-Translator: Álvaro Arranz García <aarranz@ficodes.com>\n"
 "Language-Team: Español/España\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -33,112 +34,3 @@ msgstr ""
 #: static/js/NGSI/NGSIManager.js:92
 msgid "Unexpected response from WireCloud's proxy"
 msgstr "Respuesta inesperada del proxy de WireCloud"
-
-#: static/js/wirecloud/FiWare/FiWareCatalogueView.js:41
-msgid "All stores"
-msgstr "Todas las tiendas"
-
-#: static/js/wirecloud/FiWare/FiWareCatalogueView.js:225
-msgid "loading..."
-msgstr "cargando..."
-
-#: static/js/wirecloud/FiWare/FiWareCatalogueView.js:245
-msgid "list not available"
-msgstr "lista no disponible"
-
-#: static/js/wirecloud/FiWare/FiWareCatalogueView.js:327
-msgid "Buying %(offering)s"
-msgstr "Comprando %(offering)s"
-
-#: static/js/wirecloud/FiWare/FiWareCatalogueView.js:329
-msgid ""
-"The buying process will continue in a separate window. This window will be "
-"controled by the store where the offering is hosted. After finishing the "
-"buying process, the control will return to WireCloud."
-msgstr ""
-"El proceso de compra continuará en una ventana separada. Esta ventana estará "
-"bajo el control de la tienda de la oferta. Después de que termine el proceso "
-"de compra, el control volverá a WireCloud."
-
-#: static/js/wirecloud/FiWare/Marketplace.js:90
-msgid "Unexpected response from server"
-msgstr "Respuesta inesperada del servidor"
-
-#: static/js/wirecloud/FiWare/Marketplace.js:121
-msgid "Retrieving offering info"
-msgstr "Obteniendo información de la oferta"
-
-#: static/js/wirecloud/FiWare/Offering.js:167
-msgid "Importing offering components into local repository"
-msgstr "Importando los componentes de la oferta al repositorio local"
-
-#: static/js/wirecloud/FiWare/ui/OfferingDetailsView.js:50
-msgid "Main Info"
-msgstr "General"
-
-#: static/js/wirecloud/FiWare/ui/OfferingDetailsView.js:53
-msgid "Legal"
-msgstr "Legal"
-
-#: static/js/wirecloud/FiWare/ui/OfferingDetailsView.js:57
-msgid "Pricing"
-msgstr "Precios"
-
-#: static/js/wirecloud/FiWare/ui/OfferingDetailsView.js:61
-msgid "Service level agreement"
-msgstr "Acuerdo de nivel de servicio"
-
-#: static/js/wirecloud/FiWare/ui/OfferingDetailsView.js:66
-msgid "Resources"
-msgstr "Recursos"
-
-#: static/js/wirecloud/FiWare/ui/OfferingPainter.js:59
-msgid "Uninstalling offering resources"
-msgstr "Desinstalando los recursos de la oferta"
-
-#: static/js/wirecloud/FiWare/ui/OfferingPainter.js:146
-msgid "N/A"
-msgstr "N/A"
-
-#: static/js/wirecloud/FiWare/ui/OfferingPainter.js:212
-msgid "Free"
-msgstr "Gratis"
-
-#: static/js/wirecloud/FiWare/ui/OfferingPainter.js:216
-msgid "Purchase"
-msgstr "Comprar"
-
-#: static/js/wirecloud/FiWare/ui/OfferingPainter.js:224
-#: static/js/wirecloud/FiWare/ui/OfferingResourcesPainter.js:134
-msgid "Install"
-msgstr "Instalar"
-
-#: static/js/wirecloud/FiWare/ui/OfferingPainter.js:227
-#: static/js/wirecloud/FiWare/ui/OfferingResourcesPainter.js:130
-msgid "Uninstall"
-msgstr "Desinstalar"
-
-#: static/js/wirecloud/FiWare/ui/OfferingPainter.js:231
-#: static/js/wirecloud/FiWare/ui/OfferingResourcesPainter.js:165
-msgid "Details"
-msgstr "Detalles"
-
-#: static/js/wirecloud/FiWare/ui/OfferingPainter.js:308
-msgid "No image available"
-msgstr "Imagen no disponible"
-
-#: static/js/wirecloud/FiWare/ui/OfferingResourcesPainter.js:83
-msgid "Name"
-msgstr "Nombre"
-
-#: static/js/wirecloud/FiWare/ui/OfferingResourcesPainter.js:94
-msgid "missing WireCloud metadata"
-msgstr "faltan los metadatos de WireCloud"
-
-#: static/js/wirecloud/FiWare/ui/OfferingResourcesPainter.js:120
-msgid "Actions"
-msgstr "Acciones"
-
-#: static/js/wirecloud/FiWare/ui/OfferingResourcesPainter.js:175
-msgid "Download"
-msgstr "Descargar"

--- a/src/wirecloud/fiwaretheme/locale/es/LC_MESSAGES/django.po
+++ b/src/wirecloud/fiwaretheme/locale/es/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: WireCloud 1.0\n"
+"Project-Id-Version: WireCloud 1.2\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-10-23 11:25+0200\n"
 "PO-Revision-Date: 2016-09-21 01:46+0200\n"

--- a/src/wirecloud/platform/__init__.py
+++ b/src/wirecloud/platform/__init__.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Wirecloud.  If not, see <http://www.gnu.org/licenses/>.
 
-__version_info__ = (1, 1, 1)
+__version_info__ = (1, 2, 0)
 __version__ = '.'.join(map(str, __version_info__))
 __application_mashup_version_info__ = (2, 2)
 __application_mashup_version__ = '.'.join(map(str, __application_mashup_version_info__))

--- a/src/wirecloud/platform/locale/es/LC_MESSAGES/django.po
+++ b/src/wirecloud/platform/locale/es/LC_MESSAGES/django.po
@@ -2,14 +2,15 @@
 # Copyright (C) 2015-2016 CoNWeT Lab., Universidad Politécnica de Madrid
 # This file is distributed under the same license as the WireCloud package.
 # Álvaro Arranz García <aarranz@fi.upm.es>, 2015-2016.
+# Álvaro Arranz García <aarranz@ficodes.com>, 2018.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: WireCloud 1.0\n"
+"Project-Id-Version: WireCloud 1.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-23 11:34+0200\n"
+"POT-Creation-Date: 2018-10-24 13:01+0200\n"
 "PO-Revision-Date: 2016-09-21 01:50+0200\n"
-"Last-Translator: Álvaro Arranz García <aarranz@fi.upm.es>\n"
+"Last-Translator: Álvaro Arranz García <aarranz@ficodes.com>\n"
 "Language-Team: Español/España\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -52,71 +53,71 @@ msgstr "equipo"
 msgid "teams"
 msgstr "equipos"
 
-#: core/plugins.py:269
+#: core/plugins.py:267
 msgid "Language"
 msgstr "Idioma"
 
-#: core/plugins.py:270
+#: core/plugins.py:268
 msgid "Current language used in the platform"
 msgstr "Idioma actualmente utilizado en la plataforma"
 
-#: core/plugins.py:273
+#: core/plugins.py:271
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: core/plugins.py:274
+#: core/plugins.py:272
 msgid "User name of the current logged user"
 msgstr "Nombre de usuario del usuario actual"
 
-#: core/plugins.py:277
+#: core/plugins.py:275
 msgid "Full name"
 msgstr "Nombre completo"
 
-#: core/plugins.py:278
+#: core/plugins.py:276
 msgid "Full name of the logged user"
 msgstr "Nombre completo del usuario actual"
 
-#: core/plugins.py:281
+#: core/plugins.py:279
 msgid "Avatar"
 msgstr "Avatar"
 
-#: core/plugins.py:282
+#: core/plugins.py:280
 msgid "URL of the avatar"
 msgstr "URL del avatar"
 
-#: core/plugins.py:285
+#: core/plugins.py:283
 msgid "Is Anonymous"
 msgstr "Es anónimo"
 
-#: core/plugins.py:286
+#: core/plugins.py:284
 msgid "Boolean. Designates whether current user is logged in the system."
 msgstr ""
 "Boleano. Indica cuando hay un usuario registrado actualmente en el sistema."
 
-#: core/plugins.py:289
+#: core/plugins.py:287
 msgid "Is Staff"
 msgstr "Es personal"
 
-#: core/plugins.py:290
+#: core/plugins.py:288
 msgid "Boolean. Designates whether current user can access the admin site."
 msgstr ""
 "Boleano. Indica cuando el usuario actual puede acceder al panel de "
 "administración."
 
-#: core/plugins.py:293
+#: core/plugins.py:291
 msgid "Is Superuser"
 msgstr "Es superusuario"
 
-#: core/plugins.py:294
+#: core/plugins.py:292
 msgid "Boolean. Designates whether current user is a super user."
 msgstr ""
 "Booleano. Indica cuando el usuario actualmente registrado es un super usuario"
 
-#: core/plugins.py:297
+#: core/plugins.py:295
 msgid "Mode"
 msgstr "Modo"
 
-#: core/plugins.py:298
+#: core/plugins.py:296
 msgid ""
 "Rendering mode used by the platform (available modes: classic, smartphone "
 "and embedded)"
@@ -124,35 +125,35 @@ msgstr ""
 "Modo de funcionamiento usado por la plataforma (modos disponibles: classic, "
 "smartphone y embedded)"
 
-#: core/plugins.py:301
+#: core/plugins.py:299
 msgid "Orientation"
 msgstr "Orientación"
 
-#: core/plugins.py:302
+#: core/plugins.py:300
 msgid "Current screen orientation"
 msgstr "Orientación actual de la plataforma"
 
-#: core/plugins.py:305
+#: core/plugins.py:303
 msgid "Theme"
 msgstr "Estilo"
 
-#: core/plugins.py:306
+#: core/plugins.py:304
 msgid "Name of the theme used by the platform"
 msgstr "Nombre del estilo usado por la plataforma"
 
-#: core/plugins.py:309
+#: core/plugins.py:307
 msgid "Version"
 msgstr "Versión"
 
-#: core/plugins.py:310
+#: core/plugins.py:308
 msgid "Version of the platform"
 msgstr "Versión de la plataforma"
 
-#: core/plugins.py:313
+#: core/plugins.py:311
 msgid "Version Hash"
 msgstr "Hash de la versión"
 
-#: core/plugins.py:314
+#: core/plugins.py:312
 msgid ""
 "Hash for the current version of the platform. This hash changes when the "
 "platform is updated or when an addon is added or removed"
@@ -160,58 +161,59 @@ msgstr ""
 "Hash asignado a la versión actual de la plataforma. Este bash cambia cuando "
 "la plataforma se actualiza o cuando un adán es activado o desactivado."
 
-#: core/plugins.py:325
+#: core/plugins.py:323
 msgid "Anonymous"
 msgstr "Anónimo"
 
-#: core/plugins.py:346 workspace/models.py:44 workspace/models.py:112
+#: core/plugins.py:344 workspace/models.py:43 workspace/models.py:111
 msgid "Title"
 msgstr "Título"
 
-#: core/plugins.py:347
+#: core/plugins.py:345
 msgid "Current title of the workspace"
 msgstr "Título actual del entorno de trabajo"
 
-#: core/plugins.py:350 iwidget/models.py:34 markets/models.py:31
+#: core/plugins.py:348 iwidget/models.py:34 markets/models.py:31
 #: markets/models.py:49 preferences/models.py:39 preferences/models.py:54
-#: preferences/models.py:70 workspace/models.py:42 workspace/models.py:111
+#: preferences/models.py:70 workspace/models.py:41 workspace/models.py:110
 msgid "Name"
 msgstr "Nombre"
 
-#: core/plugins.py:351
+#: core/plugins.py:349
 msgid "Current name of the workspace"
 msgstr "Nombre actual del entorno de trabajo"
 
-#: core/plugins.py:354
+#: core/plugins.py:352
 msgid "Owner"
 msgstr "Dueño"
 
-#: core/plugins.py:355
+#: core/plugins.py:353
 msgid "Workspace's owner username"
 msgstr "Nombre de usuario del dueño del entorno de trabajo"
 
-#: core/plugins.py:358 workspace/models.py:53
+#: core/plugins.py:356 workspace/models.py:52
 msgid "Description"
 msgstr "Descripción"
 
-#: core/plugins.py:359
+#: core/plugins.py:357
 msgid "Short description of the workspace without formating"
 msgstr "Descripción corta del dashboard sin formato"
 
-#: core/plugins.py:362 workspace/models.py:54
+#: core/plugins.py:360 workspace/models.py:53
 msgid "Long description"
 msgstr "Descripción larga"
 
-#: core/plugins.py:363
+#: core/plugins.py:361
 msgid ""
 "Detailed workspace's description. This description can contain formatting."
-msgstr "Descripción detallada del workspace. Esta descripción puede contener formato."
+msgstr ""
+"Descripción detallada del workspace. Esta descripción puede contener formato."
 
-#: core/plugins.py:378 markets/models.py:32
+#: core/plugins.py:376 markets/models.py:32
 msgid "Public"
 msgstr "Público"
 
-#: core/plugins.py:381
+#: core/plugins.py:379
 msgid ""
 "Allow any user to open this workspace (in read-only mode). (default: "
 "disabled)"
@@ -219,33 +221,33 @@ msgstr ""
 "Permite a cualquier usuario acceder a este entorno de trabajo (en modo de "
 "solo lectura). (valor por defecto: deshabilitado) "
 
-#: core/plugins.py:386
+#: core/plugins.py:384
 msgid "Share list"
 msgstr "Lista de compartidos"
 
-#: core/plugins.py:389
+#: core/plugins.py:387
 msgid "List of users with access to this workspace. (default: [])"
 msgstr ""
 "Lista de usuarios con acceso a este entorno de trabajo. (valor por defecto: "
 "[])"
 
-#: core/plugins.py:394
+#: core/plugins.py:392
 msgid "Default layout"
 msgstr "Esquema por defecto"
 
-#: core/plugins.py:397
+#: core/plugins.py:395
 msgid "Base"
 msgstr "Base"
 
-#: core/plugins.py:398
+#: core/plugins.py:396
 msgid "Free"
 msgstr "Libre"
 
-#: core/plugins.py:400
+#: core/plugins.py:398
 msgid "Default layout for the new widgets."
 msgstr "Distribución por defecto para los nuevos widgets."
 
-#: core/plugins.py:412
+#: core/plugins.py:410
 msgid "Base layout"
 msgstr "Distribución base"
 
@@ -441,7 +443,9 @@ msgstr "opción user inválida"
 #: markets/views.py:80
 msgid ""
 "You don't have permissions for adding marketplaces in name of other user"
-msgstr "No tienes permisos suficientes para añadir marketplaces en nombre de otros usuarios"
+msgstr ""
+"No tienes permisos suficientes para añadir marketplaces en nombre de otros "
+"usuarios"
 
 #: markets/views.py:102 markets/views.py:105 markets/views.py:132
 msgid "You are not allowed to delete this market"
@@ -545,11 +549,13 @@ msgstr "Las preferencias de solo lectura no se pueden actualizar"
 #: wiring/views.py:240
 msgid "Read only and hidden properties cannot be created using this API"
 msgstr ""
-"No se pueden crear variables persistentes de solo lectura u ocultas usando esta API"
+"No se pueden crear variables persistentes de solo lectura u ocultas usando "
+"esta API"
 
 #: wiring/views.py:249
 msgid "Read only and hidden properties cannot be removed"
-msgstr "Las variables persistentes de solo lectura y ocultas no se pueden eliminar"
+msgstr ""
+"Las variables persistentes de solo lectura y ocultas no se pueden eliminar"
 
 #: wiring/views.py:321 wiring/views.py:342
 msgid "Invalid JSON patch"
@@ -584,43 +590,43 @@ msgid "This is the wiring description of the merged mashup."
 msgstr ""
 "Esta es la descripción del comportamiento creado para el mashup mezclado."
 
-#: workspace/models.py:41
+#: workspace/models.py:40
 msgid "Creator"
 msgstr "Creador"
 
-#: workspace/models.py:46
+#: workspace/models.py:45
 msgid "Creation Date"
 msgstr "Fecha de creación"
 
-#: workspace/models.py:47
+#: workspace/models.py:46
 msgid "Last Modification Date"
 msgstr "Fecha de última modificación"
 
-#: workspace/models.py:49
+#: workspace/models.py:48
 msgid "Searchable"
 msgstr "Buscable"
 
-#: workspace/models.py:50
+#: workspace/models.py:49
 msgid "Available to all users"
 msgstr "Disponible para todos los usuarios"
 
-#: workspace/models.py:51
+#: workspace/models.py:50
 msgid "Users"
 msgstr "Usuarios"
 
-#: workspace/models.py:52
+#: workspace/models.py:51
 msgid "Groups"
 msgstr "Grupos"
 
-#: workspace/models.py:97
+#: workspace/models.py:96
 msgid "Manager"
 msgstr "Gestor"
 
-#: workspace/models.py:98
+#: workspace/models.py:97
 msgid "Reason Ref"
 msgstr "Referencia de razón"
 
-#: workspace/models.py:98
+#: workspace/models.py:97
 msgid ""
 "Reference to the reason why it was added. Used by Workspace Managers to sync "
 "workspaces"
@@ -628,11 +634,11 @@ msgstr ""
 "Referencia a la razón por la que fue añadido. Este campo es usado por los "
 "gestores de entornos de trabajo para sincronizar los entornos de trabajo"
 
-#: workspace/models.py:114
+#: workspace/models.py:113
 msgid "Visible"
 msgstr "Visible"
 
-#: workspace/models.py:116
+#: workspace/models.py:115
 msgid "Workspace"
 msgstr "Entorno de trabajo"
 

--- a/src/wirecloud/platform/locale/es/LC_MESSAGES/djangojs.po
+++ b/src/wirecloud/platform/locale/es/LC_MESSAGES/djangojs.po
@@ -2,14 +2,15 @@
 # Copyright (C) 2015-2016 CoNWeT Lab., Universidad Politécnica de Madrid
 # This file is distributed under the same license as the WireCloud package.
 # Álvaro Arranz García <aarranz@fi.upm.es>, 2015-2016.
+# Álvaro Arranz García <aarranz@ficodes.com>, 2018.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: WireCloud 1.0\n"
+"Project-Id-Version: WireCloud 1.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-23 11:34+0200\n"
+"POT-Creation-Date: 2018-10-24 13:01+0200\n"
 "PO-Revision-Date: 2017-10-23 12:12+0200\n"
-"Last-Translator: Álvaro Arranz García <aarranz@fi.upm.es>\n"
+"Last-Translator: Álvaro Arranz García <aarranz@ficodes.com>\n"
 "Language-Team: Español/España\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -19,7 +20,7 @@ msgstr ""
 "X-Generator: Poedit 2.0.4\n"
 
 #: static/js/WirecloudAPI/DashboardManagementAPI.js:154
-#: static/js/wirecloud/ui/WorkspaceView.js:424
+#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:103
 msgid "Do you really want to remove the \"%(name)s\" workspace?"
 msgstr "¿Realmente quieres eliminar el entorno de trabajo \"%(name)s\"?"
 
@@ -81,8 +82,8 @@ msgstr "Fecha de creación"
 
 #: static/js/catalogue/CatalogueSearchView.js:134
 #: static/js/wirecloud/Widget.js:240
-#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:400
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:721
+#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:291
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:718
 #: static/js/wirecloud/ui/WiringEditor/ComponentDraggablePrefs.js:148
 #: static/js/wirecloud/ui/WiringEditor/ComponentPrefs.js:100
 #: static/js/wirecloud/wiring/Operator.js:164
@@ -118,15 +119,15 @@ msgstr "Operadores"
 msgid "Clear filters"
 msgstr "Quitar filtros"
 
-#: static/js/catalogue/CatalogueView.js:50
+#: static/js/catalogue/CatalogueView.js:51
 msgid "Uninstall"
 msgstr "Desinstalar"
 
-#: static/js/catalogue/CatalogueView.js:56
+#: static/js/catalogue/CatalogueView.js:57
 msgid "Install"
 msgstr "Instalar"
 
-#: static/js/catalogue/CatalogueView.js:224
+#: static/js/catalogue/CatalogueView.js:228
 msgid ""
 "Do you really want to remove the \"%(name)s\" (vendor: \"%(vendor)s\", "
 "version: \"%(version)s\") component?"
@@ -146,20 +147,20 @@ msgstr "Descargando los operadores afectados"
 msgid "Purging %(componenttype)s info"
 msgstr "Eliminando la información sobre el %(componenttype)s"
 
-#: static/js/wirecloud/LocalCatalogue.js:149
+#: static/js/wirecloud/LocalCatalogue.js:137
 #: static/js/wirecloud/WorkspaceCatalogue.js:81
 msgid "Error loading %(resource)s metadata"
 msgstr "Error cargando los metadatos de %(resource)s"
 
-#: static/js/wirecloud/LocalCatalogue.js:187
+#: static/js/wirecloud/LocalCatalogue.js:175
 msgid "Uninstalling all versions of %(title)s (%(group_id)s)"
 msgstr "Desinstalando todas las versiones de %(title)s (%(group_id)s)"
 
-#: static/js/wirecloud/LocalCatalogue.js:194
+#: static/js/wirecloud/LocalCatalogue.js:182
 msgid "Uninstalling %(title)s (%(uri)s)"
 msgstr "Desinstalando %(title)s (%(uri)s)"
 
-#: static/js/wirecloud/LocalCatalogue.js:294
+#: static/js/wirecloud/LocalCatalogue.js:282
 msgid "Invalid component type: %(type)s"
 msgstr "Typo de componente inválido: %(type)s"
 
@@ -169,9 +170,9 @@ msgstr "Error HTTP %(errorCode)s - %(errorDesc)s"
 
 #: static/js/wirecloud/MarketManager.js:50
 #: static/js/wirecloud/MarketManager.js:81
-#: static/js/wirecloud/MarketManager.js:111 static/js/wirecloud/Wiring.js:233
-#: static/js/wirecloud/Workspace.js:304 static/js/wirecloud/Workspace.js:440
-#: static/js/wirecloud/Workspace.js:495 static/js/wirecloud/WorkspaceTab.js:223
+#: static/js/wirecloud/MarketManager.js:111 static/js/wirecloud/Wiring.js:235
+#: static/js/wirecloud/Workspace.js:305 static/js/wirecloud/Workspace.js:441
+#: static/js/wirecloud/Workspace.js:496 static/js/wirecloud/WorkspaceTab.js:223
 #: static/js/wirecloud/WorkspaceTab.js:268 static/js/wirecloud/core.js:56
 #: static/js/wirecloud/core.js:458 static/js/wirecloud/core.js:527
 #: static/js/wirecloud/core.js:532
@@ -225,7 +226,7 @@ msgstr "Detectar el idioma del navegador"
 #: static/js/wirecloud/ui/WiringEditor/ComponentDraggablePrefs.js:86
 #: static/js/wirecloud/ui/WiringEditor/ComponentPrefs.js:73
 #: static/js/wirecloud/ui/WorkspaceTabViewMenuItems.js:70
-#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:93
+#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:94
 msgid "Settings"
 msgstr "Configurar"
 
@@ -353,7 +354,7 @@ msgstr "Haz click en <em>Renombrar</em>"
 #: static/js/wirecloud/ui/WiringEditor/ComponentDraggablePrefs.js:66
 #: static/js/wirecloud/ui/WiringEditor/ComponentPrefs.js:63
 #: static/js/wirecloud/ui/WorkspaceTabViewMenuItems.js:57
-#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:63
+#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:64
 msgid "Rename"
 msgstr "Renombrar"
 
@@ -955,7 +956,7 @@ msgid "The %(type)s was replaced using v%(version)s successfully."
 msgstr ""
 "El %(type)s ha sido correctamente reemplazado usando la versión v%(version)s."
 
-#: static/js/wirecloud/Widget.js:776 static/js/wirecloud/Wiring.js:307
+#: static/js/wirecloud/Widget.js:776 static/js/wirecloud/Wiring.js:309
 msgid "Failed to load widget."
 msgstr "Error al cargar el widget."
 
@@ -992,15 +993,15 @@ msgid "[Widget; Vendor: %(vendor)s, Name: %(name)s, Version: %(version)s]"
 msgstr ""
 "[Widget; Distribuidor: %(vendor)s, Nombre: %(name)s, Versión: %(versión)s]"
 
-#: static/js/wirecloud/Wiring.js:302 static/js/wirecloud/wiring/Operator.js:496
+#: static/js/wirecloud/Wiring.js:304 static/js/wirecloud/wiring/Operator.js:496
 msgid "Failed to load operator."
 msgstr "Error al cargar el operador."
 
-#: static/js/wirecloud/Workspace.js:578
+#: static/js/wirecloud/Workspace.js:579
 msgid "Tab %(index)s"
 msgstr "Pestaña %(index)s"
 
-#: static/js/wirecloud/Workspace.js:584
+#: static/js/wirecloud/Workspace.js:585
 msgid "%(base) (%(copy)s)"
 msgstr "%(base) (%(copy)s)"
 
@@ -1180,19 +1181,6 @@ msgstr "Falta el parámetro name o title"
 msgid "Workspace and mashup options cannot be used at the same time"
 msgstr "Las opciones workspace y mashup no pueden ser usadas al mismo tiempo"
 
-#: static/js/wirecloud/ui/AlertWindowMenu.js:34
-#: static/js/wirecloud/ui/MessageWindowMenu.js:29
-msgid "Warning"
-msgstr "Advertencia"
-
-#: static/js/wirecloud/ui/AlertWindowMenu.js:41
-msgid "Yes"
-msgstr "Sí"
-
-#: static/js/wirecloud/ui/AlertWindowMenu.js:42
-msgid "No"
-msgstr "No"
-
 #: static/js/wirecloud/ui/ComponentSidebar.js:70
 msgid "Add to workspace"
 msgstr "Añadir al entorno de trabajo"
@@ -1210,7 +1198,6 @@ msgstr ""
 "layout."
 
 #: static/js/wirecloud/ui/EmbedCodeWindowMenu.js:51
-#: static/js/wirecloud/ui/MessageWindowMenu.js:43
 msgid "Accept"
 msgstr "Aceptar"
 
@@ -1330,9 +1317,9 @@ msgstr ""
 "de Mis Recursos.</li></ul>"
 
 #: static/js/wirecloud/ui/MarketplaceView.js:158
-#: static/js/wirecloud/ui/MyResourcesView.js:137
-#: static/js/wirecloud/ui/MyResourcesView.js:155
-#: static/js/wirecloud/ui/WorkspaceView.js:54
+#: static/js/wirecloud/ui/MyResourcesView.js:138
+#: static/js/wirecloud/ui/MyResourcesView.js:156
+#: static/js/wirecloud/ui/WorkspaceView.js:55
 msgid "My Resources"
 msgstr "Mis recursos"
 
@@ -1352,52 +1339,44 @@ msgstr "Marketplace"
 msgid "Marketplace - %(marketname)s"
 msgstr "Marketplace - %(marketname)s"
 
-#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:61
-#: static/js/wirecloud/ui/MyResourcesView.js:55
+#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:62
+#: static/js/wirecloud/ui/MyResourcesView.js:56
 msgid "Upload"
 msgstr "Subir"
 
-#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:68
+#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:69
 msgid "Add new marketplace"
 msgstr "Añadir un nuevo marketplace"
 
-#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:74
+#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:75
 #: static/js/wirecloud/ui/NewWorkspaceWindowMenu.js:49
 msgid "Name"
 msgstr "Nombre"
 
-#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:79
+#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:80
 msgid "URL"
 msgstr "URL"
 
-#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:86
+#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:87
 msgid "Type"
 msgstr "Tipo"
 
-#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:93
+#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:94
 #: static/js/wirecloud/ui/SharingWindowMenu.js:46
 msgid "Public"
 msgstr "Público"
 
-#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:96
+#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:97
 msgid "Add marketplace"
 msgstr "Añadir marketplace"
 
-#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:115
+#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:116
 msgid "Delete marketplace"
 msgstr "Borrar marketplace"
 
-#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:117
+#: static/js/wirecloud/ui/MarketplaceViewMenuItems.js:118
 msgid "Do you really want to remove the marketplace \"%(marketName)s\"?"
 msgstr "¿Realmente quieres eliminar el marketplace \"%(marketName)s\"?"
-
-#: static/js/wirecloud/ui/MessageWindowMenu.js:29
-msgid "Error"
-msgstr "Error"
-
-#: static/js/wirecloud/ui/MessageWindowMenu.js:29
-msgid "Info"
-msgstr "Info"
 
 #: static/js/wirecloud/ui/MissingDependenciesWindowMenu.js:38
 msgid "Missing dependencies"
@@ -1413,8 +1392,8 @@ msgid ""
 msgstr "Podrás continuar una vez todas las dependencias sean satisfechas."
 
 #: static/js/wirecloud/ui/MissingDependenciesWindowMenu.js:59
-#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:387
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:739
+#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:376
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:736
 msgid "Continue"
 msgstr "Continuar"
 
@@ -1422,15 +1401,15 @@ msgstr "Continuar"
 #: static/js/wirecloud/ui/PreferencesWindowMenu.js:222
 #: static/js/wirecloud/ui/SharingWindowMenu.js:85
 #: static/js/wirecloud/ui/UpgradeWindowMenu.js:137
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:740
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:737
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: static/js/wirecloud/ui/MyResourcesView.js:43
+#: static/js/wirecloud/ui/MyResourcesView.js:44
 msgid "Empty resource list"
 msgstr "Lista de recursos vacía"
 
-#: static/js/wirecloud/ui/MyResourcesView.js:44
+#: static/js/wirecloud/ui/MyResourcesView.js:45
 msgid ""
 "Currently, you do not have access to any component. You can get components "
 "using the Marketplace view or by uploading components manually using the "
@@ -1440,16 +1419,16 @@ msgstr ""
 "usando la vista de Marketplace o subiendo recursos de forma manual usando el "
 "botón Subir."
 
-#: static/js/wirecloud/ui/MyResourcesView.js:65
-#: static/js/wirecloud/ui/WorkspaceView.js:63
+#: static/js/wirecloud/ui/MyResourcesView.js:66
+#: static/js/wirecloud/ui/WorkspaceView.js:64
 msgid "Get more components"
 msgstr "Obtener más componentes"
 
-#: static/js/wirecloud/ui/MyResourcesView.js:152
+#: static/js/wirecloud/ui/MyResourcesView.js:153
 msgid "My Resources - %(resource)s"
 msgstr "Mis recursos - %(resource)s"
 
-#: static/js/wirecloud/ui/MyResourcesView.js:265
+#: static/js/wirecloud/ui/MyResourcesView.js:266
 msgid ""
 "You have not configured any marketplace to upload this resource. Please, "
 "configure one on the Marketplace view."
@@ -1457,7 +1436,7 @@ msgstr ""
 "No has configurado ningún marketplace en el que que subir este recurso. Por "
 "favor, configura uno en la vista Marketplace."
 
-#: static/js/wirecloud/ui/MyResourcesView.js:348
+#: static/js/wirecloud/ui/MyResourcesView.js:352
 msgid ""
 "Do you really want to remove the \"%(name)s\" (vendor: \"%(vendor)s\", "
 "version: \"%(version)s\") resource?"
@@ -1465,7 +1444,7 @@ msgstr ""
 "¿Realmente quieres eliminar el recurso \"%(name)s\" (distribuidor: "
 "\"%(vendor)s\", versión: \"%(version)s\")?"
 
-#: static/js/wirecloud/ui/MyResourcesView.js:376
+#: static/js/wirecloud/ui/MyResourcesView.js:378
 msgid ""
 "Do you really want to remove all versions of the (vendor: \"%(vendor)s\", "
 "name: \"%(name)s\") resource?"
@@ -1572,7 +1551,7 @@ msgid "Use current value"
 msgstr "Usar el valor actual"
 
 #: static/js/wirecloud/ui/ParametrizedTextInputInterface.js:75
-#: static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js:275
+#: static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js:276
 #: static/js/wirecloud/ui/WiringEditor/Connection.js:254
 msgid "Add"
 msgstr "Añadir"
@@ -1697,11 +1676,11 @@ msgstr ""
 "contraseñas) serán compartidas por defecto."
 
 #: static/js/wirecloud/ui/PublishWorkspaceWindowMenu.js:132
-#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:57
+#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:58
 #: static/js/wirecloud/ui/WiringEditor/Component.js:48
-#: static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js:49
+#: static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js:50
 #: static/js/wirecloud/ui/WiringEditor/Connection.js:78
-#: static/js/wirecloud/ui/WorkspaceTabView.js:126
+#: static/js/wirecloud/ui/WorkspaceTabView.js:127
 msgid "Preferences"
 msgstr "Preferencias"
 
@@ -1741,29 +1720,29 @@ msgstr "Usuarios y grupos con acceso"
 msgid "Add a person or an organization"
 msgstr "Añade una persona o una organización"
 
-#: static/js/wirecloud/ui/SharingWindowMenu.js:158
+#: static/js/wirecloud/ui/SharingWindowMenu.js:160
 msgid "(You)"
 msgstr "(Tú)"
 
-#: static/js/wirecloud/ui/SharingWindowMenu.js:169
+#: static/js/wirecloud/ui/SharingWindowMenu.js:171
 msgid "Owner"
 msgstr "Dueño"
 
-#: static/js/wirecloud/ui/SharingWindowMenu.js:171
+#: static/js/wirecloud/ui/SharingWindowMenu.js:173
 msgid "Can view"
 msgstr "Puede ver"
 
-#: static/js/wirecloud/ui/SharingWindowMenu.js:177
+#: static/js/wirecloud/ui/SharingWindowMenu.js:179
 #: static/js/wirecloud/ui/WidgetView.js:111
-#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:64
-#: static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js:56
-#: static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js:286
-#: static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js:297
+#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:65
+#: static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js:57
+#: static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js:287
+#: static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js:298
 #: static/js/wirecloud/ui/WiringEditor/Connection.js:68
 #: static/js/wirecloud/ui/WiringEditor/Connection.js:266
 #: static/js/wirecloud/ui/WiringEditor/Connection.js:278
 #: static/js/wirecloud/ui/WorkspaceTabViewMenuItems.js:76
-#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:100
+#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:101
 msgid "Remove"
 msgstr "Eliminar"
 
@@ -1857,15 +1836,15 @@ msgstr "Cambiar usuario"
 msgid "Sign out"
 msgstr "Salir"
 
-#: static/js/wirecloud/ui/WiringEditor.js:177
+#: static/js/wirecloud/ui/WiringEditor.js:169
 msgid "%(workspace_title)s - Wiring"
 msgstr "%(workspace_title)s - Wiring"
 
-#: static/js/wirecloud/ui/WiringEditor.js:364
+#: static/js/wirecloud/ui/WiringEditor.js:390
 msgid "Hello, welcome to the Wiring Editor view!"
 msgstr "Hola, ¡Bienvenido al Editor del Wiring!"
 
-#: static/js/wirecloud/ui/WiringEditor.js:365
+#: static/js/wirecloud/ui/WiringEditor.js:391
 msgid ""
 "In this view you can connect all the components of your dashboard in a "
 "visual way."
@@ -1873,7 +1852,7 @@ msgstr ""
 "En esta vista puedes conectar todos los componentes del panel de una forma "
 "visual."
 
-#: static/js/wirecloud/ui/WiringEditor.js:371
+#: static/js/wirecloud/ui/WiringEditor.js:397
 msgid ""
 "Open the sidebar using the <em>Find components</em> button and drag &amp; "
 "drop components (operators/widgets) from the sidebar for being able to "
@@ -1883,15 +1862,15 @@ msgstr ""
 "arrastrar y soltar componentes (operadores/widgets) desde el panel lateral y "
 "poder conectarlos como quieras."
 
-#: static/js/wirecloud/ui/WiringEditor.js:378
+#: static/js/wirecloud/ui/WiringEditor.js:404
 msgid "Find components"
 msgstr "Buscar componentes"
 
-#: static/js/wirecloud/ui/WiringEditor.js:391
+#: static/js/wirecloud/ui/WiringEditor.js:417
 msgid "List behaviours"
 msgstr "Listar comportamientos"
 
-#: static/js/wirecloud/ui/WiringEditor.js:659
+#: static/js/wirecloud/ui/WiringEditor.js:653
 msgid ""
 "The connection will also be modified for the rest of behaviours, would you "
 "like to continue?"
@@ -1899,25 +1878,34 @@ msgstr ""
 "La conexión será modificada también en el resto de comportamientos. ¿Desea "
 "continuar?"
 
-#: static/js/wirecloud/ui/WiringEditor.js:738
+#: static/js/wirecloud/ui/WiringEditor.js:729
 msgid "Behaviour"
 msgstr "Comportamiento"
 
-#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:113
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:724
+#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:120
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:721
 msgid "New behaviour"
 msgstr "Nuevo comportamiento"
 
-#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:114
-#: static/js/wirecloud/ui/WiringEditor/Endpoint.js:117
+#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:121
+#: static/js/wirecloud/ui/WiringEditor/Endpoint.js:125
 msgid "No description provided."
 msgstr "No se ha proporcionado una descripción."
 
-#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:278
+#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:272
 msgid "%(behaviour_title)s's logs"
 msgstr "Registros de %(behaviour_title)s"
 
-#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:384
+#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:292
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:719
+msgid "Description"
+msgstr "Descripción"
+
+#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:294
+msgid "Behaviour settings"
+msgstr "Configuración del comportamiento"
+
+#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:372
 msgid ""
 "The following operation is irreversible and removes the behaviour "
 "completely. Would you like to continue?"
@@ -1925,58 +1913,49 @@ msgstr ""
 "Esta operación es irreversible y eliminirá el comportamiento por completo. "
 "¿Desea continuar?"
 
-#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:388
+#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:377
 msgid "No, thank you"
 msgstr "No, gracias"
 
-#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:401
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:722
-msgid "Description"
-msgstr "Descripción"
-
-#: static/js/wirecloud/ui/WiringEditor/Behaviour.js:403
-msgid "Behaviour settings"
-msgstr "Configuración del comportamiento"
-
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:45
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:117
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:46
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:128
 msgid "Enable"
 msgstr "Activar"
 
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:52
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:53
 msgid "Create behaviour"
 msgstr "Crear comportamiento"
 
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:59
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:60
 msgid "Order behaviours"
 msgstr "Ordenar los comportamientos"
 
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:83
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:84
 msgid "New feature"
 msgstr "Nueva funcionalidad"
 
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:84
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:85
 msgid "Enable the behaviours to enjoy with a new way to handle connections."
 msgstr ""
 "Activa los comportamientos para disfrutar de una nueva forma de manejar las "
 "conexiones."
 
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:87
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:88
 msgid ""
 "<a>Click here</a> for a quick guide/tutorial on how to use this new feature."
 msgstr ""
 "Haz <a>click aquí</a> para una guía rápida/tutorial sobre como usar esta "
 "nueva funcionalidad."
 
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:110
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:114
 msgid "Disable"
 msgstr "Desactivar"
 
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:386
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:402
 msgid "The behaviour (%(title)s) was loaded."
 msgstr "El comportamiento (%(title)s) ha sido cargado correctamente."
 
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:736
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:733
 msgid ""
 "The behaviours will be removed but the components and connections will still "
 "exist, would you like to continue?"
@@ -1984,18 +1963,18 @@ msgstr ""
 "Los comportamientos serán eliminados pero los componentes y las conexiones "
 "seguirán existiendo. ¿Desea continuar?"
 
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:812
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:801
 msgid ""
 "The <strong><t:title/></strong> <t:type/> will be removed, would you like to "
 "continue?"
 msgstr ""
 "El <t:type/> <strong><t:title/></strong> será borrado. ¿Desea continuar?"
 
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:832
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:821
 msgid "<li>The <strong><t:title/></strong> <t:type/>.</li>"
 msgstr "<li>El <t:type/> <strong><t:title/></strong>.</li>"
 
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:838
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:827
 msgid ""
 "<p>These components only exist within the current behaviour <strong><t:title/"
 "></strong>:</p><ul><t:components/></ul><p>Would you like to continue?</p>"
@@ -2004,7 +1983,7 @@ msgstr ""
 "<strong><t:title/></strong>:</p><ul><t:components/></ul><p>¿Desea continuar?"
 "</p>"
 
-#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:860
+#: static/js/wirecloud/ui/WiringEditor/BehaviourEngine.js:848
 msgid ""
 "The <strong><t:title/></strong> <t:type/> will be <strong>definitely</"
 "strong> removed, would you like to continue?"
@@ -2028,11 +2007,11 @@ msgstr "en uso"
 msgid "no endpoints"
 msgstr "sin conectores"
 
-#: static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js:709
+#: static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js:703
 msgid "Missing"
 msgstr "Ausente"
 
-#: static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js:711
+#: static/js/wirecloud/ui/WiringEditor/ComponentDraggable.js:705
 msgid "%(count)s error"
 msgid_plural "%(count)s errors"
 msgstr[0] "%(count)s error"
@@ -2111,58 +2090,58 @@ msgstr "Renombrar pestaña"
 msgid "Set as initial"
 msgstr "Configurar como inicial"
 
-#: static/js/wirecloud/ui/WorkspaceView.js:45
+#: static/js/wirecloud/ui/WorkspaceView.js:46
 msgid "Wiring"
 msgstr "Wiring"
 
-#: static/js/wirecloud/ui/WorkspaceView.js:231
+#: static/js/wirecloud/ui/WorkspaceView.js:232
 msgid "New tab"
 msgstr "Nueva pestaña"
 
-#: static/js/wirecloud/ui/WorkspaceView.js:242
-#: static/js/wirecloud/ui/WorkspaceView.js:253
+#: static/js/wirecloud/ui/WorkspaceView.js:243
+#: static/js/wirecloud/ui/WorkspaceView.js:254
 msgid "Full screen"
 msgstr "Ver a pantalla completa"
 
-#: static/js/wirecloud/ui/WorkspaceView.js:249
+#: static/js/wirecloud/ui/WorkspaceView.js:250
 msgid "Exit full screen"
 msgstr "Salir de pantalla completa"
 
-#: static/js/wirecloud/ui/WorkspaceView.js:293
+#: static/js/wirecloud/ui/WorkspaceView.js:294
 msgid "Add components"
 msgstr "Añadir componentes"
 
-#: static/js/wirecloud/ui/WorkspaceView.js:350
-#: static/js/wirecloud/ui/WorkspaceView.js:364
+#: static/js/wirecloud/ui/WorkspaceView.js:351
+#: static/js/wirecloud/ui/WorkspaceView.js:365
 msgid "loading..."
 msgstr "cargando..."
 
-#: static/js/wirecloud/ui/WorkspaceView.js:401
+#: static/js/wirecloud/ui/WorkspaceView.js:402
 msgid "The requested workspace is no longer available (it was deleted)."
 msgstr ""
 "El entorno de trabajo solicitado ya no está disponible (ha sido borrado)."
 
-#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:57
+#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:58
 msgid "New workspace"
 msgstr "Nuevo entorno de trabajo"
 
-#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:64
+#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:65
 msgid "Rename Workspace"
 msgstr "Renombrar el entorno de trabajo"
 
-#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:70
+#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:71
 msgid "Share"
 msgstr "Compartir"
 
-#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:76
+#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:77
 msgid "Upload to my resources"
 msgstr "Subir a mis recursos"
 
-#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:87
+#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:88
 msgid "Embed"
 msgstr "Incrustar"
 
-#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:88
+#: static/js/wirecloud/ui/WorkspaceViewMenuItems.js:89
 msgid "Embed Code"
 msgstr "Código a incrustar"
 


### PR DESCRIPTION
Update documentation for final 1.2 release.

- [x] Remove Django 1.8 references from the installation guide.
- [x] Ensure mkdocs builds WireCloud documentation correctly.
- [x] General documentation improvements.
- [x] Improve authentication backend documentation on the IdM section. See #327 for more details.