### PR TITLE
Fix invalid code in the create output endpoint example

### DIFF
--- a/docs/slides/3.1.7_Dynamic_dashboards.md
+++ b/docs/slides/3.1.7_Dynamic_dashboards.md
@@ -271,7 +271,7 @@ var operator = MashupPlatform.mashup.addOperator('CoNWeT/ngsientity2poi/3.0.3', 
 ### Wiring configuration
 
 ```javascript
-var poi_endpoint = MashupPlatform.widget.wiring.createOutputEndpoint();
+var poi_endpoint = MashupPlatform.widget.createOutputEndpoint();
 
 poi_endpoint.connect(operator.inputs['entityInput']);
 operator.outputs['poiOutput'].connect(map_widget.inputs['poiInput']);


### PR DESCRIPTION
This PR fixes invalid code in the create output example provided on the slides.