### PR TITLE
Add users and groups options for installing resources

### DIFF
--- a/src/wirecloud/catalogue/fixtures/selenium_test_data.json
+++ b/src/wirecloud/catalogue/fixtures/selenium_test_data.json
@@ -122,6 +122,24 @@
         }
     },
     {
+        "pk": 1,
+        "model": "platform.team",
+        "fields": {
+            "organization": 1,
+            "name": "owners",
+            "users": [4]
+        }
+    },
+    {
+        "pk": 2,
+        "model": "platform.team",
+        "fields": {
+            "organization": 1,
+            "name": "members",
+            "users": [2]
+        }
+    },
+    {
         "pk": 14,
         "model": "catalogue.catalogueresource",
         "fields": {

--- a/src/wirecloud/catalogue/management/commands/addtocatalogue.py
+++ b/src/wirecloud/catalogue/management/commands/addtocatalogue.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2012-2016 CoNWeT Lab., Universidad Politécnica de Madrid
+# Copyright (c) 2019 Future Internet Consulting and Development Solutions S.L.
 
 # This file is part of Wirecloud.
 
@@ -26,7 +27,7 @@ from django.utils.translation import override, ugettext as _
 from wirecloud.catalogue.views import add_packaged_resource
 from wirecloud.commons.utils.template import TemplateParser
 from wirecloud.commons.utils.wgt import WgtFile
-from wirecloud.platform.localcatalogue.utils import install_resource_to_user, install_resource_to_group, install_resource_to_all_users
+from wirecloud.platform.localcatalogue.utils import install_component
 
 
 class Command(BaseCommand):
@@ -104,14 +105,7 @@ class Command(BaseCommand):
                 if options['redeploy']:
                     add_packaged_resource(f, None, wgt_file=wgt_file, template=template, deploy_only=True)
                 else:
-                    for user in users:
-                        install_resource_to_user(user, file_contents=wgt_file)
-
-                    for group in groups:
-                        install_resource_to_group(group, file_contents=wgt_file)
-
-                    if public:
-                        install_resource_to_all_users(file_contents=wgt_file)
+                    install_component(wgt_file, public=public, users=users, groups=groups)
 
                 wgt_file.close()
                 f.close()

--- a/src/wirecloud/catalogue/tests/commands.py
+++ b/src/wirecloud/catalogue/tests/commands.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2015-2016 CoNWeT Lab., Universidad Politécnica de Madrid
+# Copyright (c) 2019 Future Internet Consulting and Development Solutions S.L.
 
 # This file is part of Wirecloud.
 
@@ -19,7 +20,7 @@
 
 import io
 import sys
-from unittest.mock import Mock, patch, DEFAULT
+from unittest.mock import ANY, Mock, patch, DEFAULT
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -63,7 +64,7 @@ class AddToCatalogueCommandTestCase(TestCase):
             with patch('wirecloud.catalogue.management.commands.addtocatalogue.open', create=True):
                 with patch.multiple(
                         'wirecloud.catalogue.management.commands.addtocatalogue',
-                        add_packaged_resource=DEFAULT, install_resource_to_user=DEFAULT, install_resource_to_group=DEFAULT, install_resource_to_all_users=DEFAULT,
+                        add_packaged_resource=DEFAULT, install_component=DEFAULT,
                         WgtFile=DEFAULT, TemplateParser=DEFAULT, User=DEFAULT, Group=DEFAULT, autospec=True) as context:
                     parser = Mock()
                     parser.get_resource_processed_info.return_value = {'title': "Mashable Application Component1"}
@@ -74,9 +75,9 @@ class AddToCatalogueCommandTestCase(TestCase):
 
                     # Basic assert code
                     self.assertEqual(context['add_packaged_resource'].call_count, 0)
-                    self.assertEqual(context['install_resource_to_user'].call_count, 1)
-                    self.assertEqual(context['install_resource_to_group'].call_count, 0)
-                    self.assertEqual(context['install_resource_to_all_users'].call_count, 0)
+                    self.assertEqual(context['install_component'].call_count, 1)
+                    context['User'].objects.get.assert_called_with(username="admin")
+                    context['install_component'].assert_called_with(ANY, public=False, users=[context['User'].objects.get()], groups=[])
 
         except SystemExit:
             raise CommandError('')
@@ -95,7 +96,7 @@ class AddToCatalogueCommandTestCase(TestCase):
             with patch('wirecloud.catalogue.management.commands.addtocatalogue.open', create=True):
                 with patch.multiple(
                         'wirecloud.catalogue.management.commands.addtocatalogue',
-                        add_packaged_resource=DEFAULT, install_resource_to_user=DEFAULT, install_resource_to_group=DEFAULT, install_resource_to_all_users=DEFAULT,
+                        add_packaged_resource=DEFAULT, install_component=DEFAULT,
                         WgtFile=DEFAULT, TemplateParser=DEFAULT, User=DEFAULT, Group=DEFAULT, autospec=True) as context:
                     parser = Mock()
                     parser.get_resource_processed_info.return_value = {'title': "Mashable Application Component1"}
@@ -106,9 +107,9 @@ class AddToCatalogueCommandTestCase(TestCase):
 
                     # Basic assert code
                     self.assertEqual(context['add_packaged_resource'].call_count, 0)
-                    self.assertEqual(context['install_resource_to_user'].call_count, 0)
-                    self.assertEqual(context['install_resource_to_group'].call_count, 1)
-                    self.assertEqual(context['install_resource_to_all_users'].call_count, 0)
+                    self.assertEqual(context['install_component'].call_count, 1)
+                    context['Group'].objects.get.assert_called_with(name="group1")
+                    context['install_component'].assert_called_with(ANY, public=False, users=[], groups=[context['Group'].objects.get()])
 
         except SystemExit:
             raise CommandError('')
@@ -127,7 +128,7 @@ class AddToCatalogueCommandTestCase(TestCase):
             with patch('wirecloud.catalogue.management.commands.addtocatalogue.open', create=True):
                 with patch.multiple(
                         'wirecloud.catalogue.management.commands.addtocatalogue',
-                        add_packaged_resource=DEFAULT, install_resource_to_user=DEFAULT, install_resource_to_group=DEFAULT, install_resource_to_all_users=DEFAULT,
+                        add_packaged_resource=DEFAULT, install_component=DEFAULT,
                         WgtFile=DEFAULT, TemplateParser=DEFAULT, User=DEFAULT, Group=DEFAULT, autospec=True) as context:
                     parser = Mock()
                     parser.get_resource_processed_info.return_value = {'title': "Mashable Application Component1"}
@@ -138,9 +139,8 @@ class AddToCatalogueCommandTestCase(TestCase):
 
                     # Basic assert code
                     self.assertEqual(context['add_packaged_resource'].call_count, 0)
-                    self.assertEqual(context['install_resource_to_user'].call_count, 0)
-                    self.assertEqual(context['install_resource_to_group'].call_count, 0)
-                    self.assertEqual(context['install_resource_to_all_users'].call_count, 1)
+                    self.assertEqual(context['install_component'].call_count, 1)
+                    context['install_component'].assert_called_with(ANY, public=True, users=[], groups=[])
 
         except SystemExit:
             raise CommandError('')
@@ -160,7 +160,7 @@ class AddToCatalogueCommandTestCase(TestCase):
         with patch('wirecloud.catalogue.management.commands.addtocatalogue.open', create=True):
             with patch.multiple(
                     'wirecloud.catalogue.management.commands.addtocatalogue',
-                    add_packaged_resource=DEFAULT, install_resource_to_user=DEFAULT, install_resource_to_group=DEFAULT, install_resource_to_all_users=DEFAULT,
+                    add_packaged_resource=DEFAULT, install_component=DEFAULT,
                     WgtFile=DEFAULT, TemplateParser=DEFAULT, User=DEFAULT, Group=DEFAULT, autospec=True) as context:
 
                 # Make the call to addtocatalogue
@@ -168,9 +168,7 @@ class AddToCatalogueCommandTestCase(TestCase):
 
                 # Basic assert code
                 self.assertEqual(context['add_packaged_resource'].call_count, 0)
-                self.assertEqual(context['install_resource_to_user'].call_count, 0)
-                self.assertEqual(context['install_resource_to_group'].call_count, 0)
-                self.assertEqual(context['install_resource_to_all_users'].call_count, 0)
+                self.assertEqual(context['install_component'].call_count, 0)
 
         self.options['stdout'].seek(0)
         self.assertEqual(self.options['stdout'].read(), '')

--- a/src/wirecloud/fiware/plugins.py
+++ b/src/wirecloud/fiware/plugins.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2012-2017 Conwet Lab., Universidad Politécnica de Madrid
+# Copyright (c) 2019 Future Internet Consulting and Development Solutions S.L.
 
 # This file is part of Wirecloud.
 
@@ -26,7 +27,7 @@ from django.views.decorators.cache import cache_page
 
 from wirecloud.commons.utils.wgt import WgtFile
 from wirecloud.platform.core.plugins import get_version_hash
-from wirecloud.platform.localcatalogue.utils import install_resource_to_all_users
+from wirecloud.platform.localcatalogue.utils import install_component
 from wirecloud.platform.markets.utils import MarketManager
 from wirecloud.platform.models import CatalogueResource
 from wirecloud.platform.plugins import WirecloudPlugin
@@ -214,25 +215,25 @@ class FiWarePlugin(WirecloudPlugin):
         if not CatalogueResource.objects.filter(vendor="CoNWeT", short_name="bae-browser", version="0.1.1", public=True).exists():
             updated = True
             log('Installing bae-browser widget... ', 1, ending='')
-            install_resource_to_all_users(file_contents=WgtFile(BAE_BROWSER_WIDGET))
+            install_component(WgtFile(BAE_BROWSER_WIDGET), public=True)
             log('DONE', 1)
 
         if not CatalogueResource.objects.filter(vendor="CoNWeT", short_name="bae-details", version="0.1.1", public=True).exists():
             updated = True
             log('Installing bae-details widget... ', 1, ending='')
-            install_resource_to_all_users(file_contents=WgtFile(BAE_DETAILS_WIDGET))
+            install_component(WgtFile(BAE_DETAILS_WIDGET), public=True)
             log('DONE', 1)
 
         if not CatalogueResource.objects.filter(vendor="CoNWeT", short_name="bae-search-filters", version="0.1.1", public=True).exists():
             updated = True
             log('Installing bae-search-filters widget... ', 1, ending='')
-            install_resource_to_all_users(file_contents=WgtFile(BAE_SEARCH_FILTERS_WIDGET))
+            install_component(WgtFile(BAE_SEARCH_FILTERS_WIDGET), public=True)
             log('DONE', 1)
 
         if not CatalogueResource.objects.filter(vendor="CoNWeT", short_name="bae-marketplace", version="0.1.1", public=True).exists():
             updated = True
             log('Installing bae-marketplace mashup... ', 1, ending='')
-            install_resource_to_all_users(file_contents=WgtFile(BAE_MASHUP))
+            install_component(WgtFile(BAE_MASHUP), public=True)
             log('DONE', 1)
 
         return updated

--- a/src/wirecloud/platform/core/catalogue_manager.py
+++ b/src/wirecloud/platform/core/catalogue_manager.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2012-2017 CoNWeT Lab., Universidad Politécnica de Madrid
+# Copyright (c) 2019 Future Internet Consulting and Development Solutions S.L.
 
 # This file is part of Wirecloud.
 
@@ -29,7 +30,7 @@ from wirecloud.catalogue.models import CatalogueResource
 import wirecloud.catalogue.utils as catalogue_utils
 from wirecloud.commons.utils.downloader import download_http_content, download_local_file
 from wirecloud.commons.utils.template import TemplateParser
-from wirecloud.platform.localcatalogue.utils import install_resource_to_user
+from wirecloud.platform.localcatalogue.utils import install_component
 from wirecloud.platform.markets.utils import MarketManager
 
 
@@ -52,7 +53,7 @@ class WirecloudCatalogueManager(MarketManager):
             if template is None:
                 template = TemplateParser(wgt_file.get_template())
 
-            added, resource = install_resource_to_user(user, file_contents=wgt_file, packaged=True, raise_conflicts=True)
+            added, resource = install_component(wgt_file, users=[user])
             if not added:
                 raise Exception(_('Resource already exists %(resource_id)s') % {'resource_id': resource.local_uri_part})
 

--- a/src/wirecloud/platform/core/plugins.py
+++ b/src/wirecloud/platform/core/plugins.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2012-2017 CoNWeT Lab., Universidad Politécnica de Madrid
-# Copyright (c) 2018 Future Internet Consulting and Development Solutions S.L.
+# Copyright (c) 2018-2019 Future Internet Consulting and Development Solutions S.L.
 
 # This file is part of Wirecloud.
 
@@ -29,7 +29,7 @@ from django.utils.translation import get_language, ugettext_lazy as _
 from wirecloud.commons.utils.wgt import WgtFile
 import wirecloud.platform
 from wirecloud.platform.core.catalogue_manager import WirecloudCatalogueManager
-from wirecloud.platform.localcatalogue.utils import install_resource_to_user
+from wirecloud.platform.localcatalogue.utils import install_component
 from wirecloud.platform.models import CatalogueResource, IWidget, Workspace
 from wirecloud.platform.plugins import build_url_template, get_active_features_info, WirecloudPlugin
 from wirecloud.platform.themes import get_active_theme_name
@@ -678,7 +678,7 @@ class WirecloudCorePlugin(WirecloudPlugin):
         if not CatalogueResource.objects.filter(vendor=vendor, short_name=name, version=version).exists():
             updated = True
             log('Installing the %(name)s widget... ' % {"name": name}, 1, ending='')
-            added, component = install_resource_to_user(wirecloud_user, file_contents=WgtFile(wgt))
+            added, component = install_component(WgtFile(wgt), executor_user=wirecloud_user, users=[wirecloud_user])
             IWidget.objects.filter(widget__resource__vendor=vendor, widget__resource__short_name=name).exclude(widget__resource__version=version).update(widget=component.widget, widget_uri=component.local_uri_part)
             log('DONE', 1)
 

--- a/src/wirecloud/platform/localcatalogue/views.py
+++ b/src/wirecloud/platform/localcatalogue/views.py
@@ -165,7 +165,7 @@ class ResourceCollection(Resource):
         if not request.user.is_superuser:
             if public:
                 return build_error_response(request, 403, _('You are not allowed to make resources publicly available to all users'))
-            elif len(users) > 0 and users != [request.user.username]:
+            elif len(users) > 0 and tuple(users) != (request.user,):
                 return build_error_response(request, 403, _('You are not allowed allow to install components to other users'))
             elif len(groups) > 0:
                 for group in groups:

--- a/src/wirecloud/platform/localcatalogue/views.py
+++ b/src/wirecloud/platform/localcatalogue/views.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2012-2017 CoNWeT Lab., Universidad Politécnica de Madrid
+# Copyright (c) 2019 Future Internet Consulting and Development Solutions S.L.
 
 # This file is part of Wirecloud.
 
@@ -38,7 +39,7 @@ from wirecloud.commons.utils.template import TemplateParseException, Unsupported
 from wirecloud.commons.utils.transaction import commit_on_http_success
 from wirecloud.commons.utils.wgt import InvalidContents, WgtFile
 from wirecloud.platform.localcatalogue.signals import resource_uninstalled
-from wirecloud.platform.localcatalogue.utils import install_resource_to_user, install_resource_to_all_users, fix_dev_version, install_resource_to_group
+from wirecloud.platform.localcatalogue.utils import fix_dev_version, install_component
 from wirecloud.platform.markets.utils import get_market_managers
 from wirecloud.platform.models import Workspace
 from wirecloud.platform.settings import ALLOW_ANONYMOUS_ACCESS
@@ -75,8 +76,8 @@ class ResourceCollection(Resource):
         if content_type == 'multipart/form-data':
             force_create = request.POST.get('force_create', 'false').strip().lower() == 'true'
             public = request.POST.get('public', 'false').strip().lower() == 'true'
-            user_list = [user.strip() for user in request.POST.get('users', '').split(',')]
-            group_list = [group.strip() for group in request.POST.get('groups', '').split(',')]
+            user_list = set(user.strip() for user in request.POST.get('users', '').split(',') if user != "")
+            group_list = set(group.strip() for group in request.POST.get('groups', '').split(',') if group != "")
             install_embedded_resources = request.POST.get('install_embedded_resources', 'false').strip().lower() == 'true'
             if 'file' not in request.FILES:
                 return build_error_response(request, 400, _('Missing component file in the request'))
@@ -97,8 +98,8 @@ class ResourceCollection(Resource):
 
             force_create = request.GET.get('force_create', 'false').strip().lower() == 'true'
             public = request.GET.get('public', 'false').strip().lower() == 'true'
-            user_list = [user.strip() for user in request.GET.get('users', '').split(',')]
-            group_list = [group.strip() for group in request.GET.get('groups', '').split(',')]
+            user_list = set(user.strip() for user in request.GET.get('users', '').split(',') if user != "")
+            group_list = set(group.strip() for group in request.GET.get('groups', '').split(',') if group != "")
             install_embedded_resources = request.GET.get('install_embedded_resources', 'false').strip().lower() == 'true'
         else:  # if content_type == 'application/json'
 
@@ -109,8 +110,8 @@ class ResourceCollection(Resource):
             install_embedded_resources = normalize_boolean_param(request, 'install_embedded_resources', data.get('install_embedded_resources', False))
             force_create = data.get('force_create', False)
             public = request.GET.get('public', 'false').strip().lower() == 'true'
-            user_list = [user.strip() for user in request.GET.get('user_list', '').split(',')]
-            group_list = [group.strip() for group in request.GET.get('group_list', '').split(',')]
+            user_list = set(user.strip() for user in request.GET.get('user_list', '').split(',') if user != "")
+            group_list = set(group.strip() for group in request.GET.get('group_list', '').split(',') if group != "")
             templateURL = data.get('url')
             market_endpoint = data.get('market_endpoint', None)
             headers = data.get('headers', {})
@@ -158,25 +159,20 @@ class ResourceCollection(Resource):
             return build_error_response(request, 403, _('You are not allowed to make resources publicly available to all users'))
 
         try:
+
             fix_dev_version(file_contents, request.user)
-            added, resource = install_resource_to_user(request.user, file_contents=file_contents, templateURL=templateURL)
+            if public is False and len(user_list) == 0 and len(group_list) == 0:
+                users = (request.user,)
+            else:
+                users = User.objects.filter(username__in=user_list)
+            groups = Group.objects.filter(name__in=group_list)
+
+            added, resource = install_component(file_contents, executor_user=request.user, public=public, users=users, groups=groups)
 
             if not added and force_create:
                 return build_error_response(request, 409, _('Resource already exists'))
             elif not added:
                 status_code = 200
-
-            if public:
-                install_resource_to_all_users(executor_user=request.user, file_contents=file_contents)
-            else:
-                users = User.objects.filter(username__in = user_list)
-                groups = Group.objects.filter(name__in = group_list)
-
-                for user in users:
-                    install_resource_to_user(user, file_contents=file_contents, templateURL=templateURL)
-
-                for group in groups:
-                    install_resource_to_group(group, file_contents=file_contents, templateURL=templateURL)
 
         except zipfile.BadZipfile as e:
 
@@ -213,10 +209,7 @@ class ResourceCollection(Resource):
                     resource_file = BytesIO(file_contents.read(embedded_resource['src']))
 
                     extra_resource_contents = WgtFile(resource_file)
-                    if public:
-                        extra_resource_added, extra_resource = install_resource_to_user(request.user, file_contents=extra_resource_contents, raise_conflicts=False)
-                    else:
-                        extra_resource_added, extra_resource = install_resource_to_user(request.user, file_contents=extra_resource_contents, raise_conflicts=False)
+                    extra_resource_added, extra_resource = install_component(extra_resource_contents, executor_user=request.user, public=public, users=users, groups=groups)
                     if extra_resource_added:
                         info['extra_resources'].append(extra_resource.get_processed_info(request, url_pattern_name="wirecloud.showcase_media"))
 

--- a/src/wirecloud/platform/localcatalogue/views.py
+++ b/src/wirecloud/platform/localcatalogue/views.py
@@ -75,8 +75,8 @@ class ResourceCollection(Resource):
         if content_type == 'multipart/form-data':
             force_create = request.POST.get('force_create', 'false').strip().lower() == 'true'
             public = request.POST.get('public', 'false').strip().lower() == 'true'
-            user_list = [user.strip() for user in request.POST.get('user_list', 'false').split(',')]
-            group_list = [group.strip() for group in request.POST.get('group_list', 'false').split(',')]
+            user_list = [user.strip() for user in request.POST.get('users', '').split(',')]
+            group_list = [group.strip() for group in request.POST.get('groups', '').split(',')]
             install_embedded_resources = request.POST.get('install_embedded_resources', 'false').strip().lower() == 'true'
             if 'file' not in request.FILES:
                 return build_error_response(request, 400, _('Missing component file in the request'))
@@ -97,8 +97,8 @@ class ResourceCollection(Resource):
 
             force_create = request.GET.get('force_create', 'false').strip().lower() == 'true'
             public = request.GET.get('public', 'false').strip().lower() == 'true'
-            user_list = [user.strip() for user in request.GET.get('user_list', 'false').split(',')]
-            group_list = [group.strip() for group in request.GET.get('group_list', 'false').split(',')]
+            user_list = [user.strip() for user in request.GET.get('users', '').split(',')]
+            group_list = [group.strip() for group in request.GET.get('groups', '').split(',')]
             install_embedded_resources = request.GET.get('install_embedded_resources', 'false').strip().lower() == 'true'
         else:  # if content_type == 'application/json'
 
@@ -109,8 +109,8 @@ class ResourceCollection(Resource):
             install_embedded_resources = normalize_boolean_param(request, 'install_embedded_resources', data.get('install_embedded_resources', False))
             force_create = data.get('force_create', False)
             public = request.GET.get('public', 'false').strip().lower() == 'true'
-            user_list = [user.strip() for user in request.GET.get('user_list', 'false').split(',')]
-            group_list = [group.strip() for group in request.GET.get('group_list', 'false').split(',')]
+            user_list = [user.strip() for user in request.GET.get('user_list', '').split(',')]
+            group_list = [group.strip() for group in request.GET.get('group_list', '').split(',')]
             templateURL = data.get('url')
             market_endpoint = data.get('market_endpoint', None)
             headers = data.get('headers', {})

--- a/src/wirecloud/platform/localcatalogue/views.py
+++ b/src/wirecloud/platform/localcatalogue/views.py
@@ -23,6 +23,7 @@ import json
 import os
 import zipfile
 
+from django.contrib.auth.models import User, Group
 from django.db.models import Q
 from django.http import HttpResponse
 from django.shortcuts import get_list_or_404, get_object_or_404
@@ -37,7 +38,7 @@ from wirecloud.commons.utils.template import TemplateParseException, Unsupported
 from wirecloud.commons.utils.transaction import commit_on_http_success
 from wirecloud.commons.utils.wgt import InvalidContents, WgtFile
 from wirecloud.platform.localcatalogue.signals import resource_uninstalled
-from wirecloud.platform.localcatalogue.utils import install_resource_to_user, install_resource_to_all_users, fix_dev_version
+from wirecloud.platform.localcatalogue.utils import install_resource_to_user, install_resource_to_all_users, fix_dev_version, install_resource_to_group
 from wirecloud.platform.markets.utils import get_market_managers
 from wirecloud.platform.models import Workspace
 from wirecloud.platform.settings import ALLOW_ANONYMOUS_ACCESS
@@ -73,7 +74,7 @@ class ResourceCollection(Resource):
         content_type = get_content_type(request)[0]
         if content_type == 'multipart/form-data':
             force_create = request.POST.get('force_create', 'false').strip().lower() == 'true'
-            public = request.POST.get('public', 'false').strip().lower() == 'true'
+            user_list = [user.strip() for user in request.POST.get('user_list', 'false').split(',')]
             install_embedded_resources = request.POST.get('install_embedded_resources', 'false').strip().lower() == 'true'
             if 'file' not in request.FILES:
                 return build_error_response(request, 400, _('Missing component file in the request'))
@@ -93,7 +94,8 @@ class ResourceCollection(Resource):
                 return build_error_response(request, 400, _('The uploaded file is not a zip file'))
 
             force_create = request.GET.get('force_create', 'false').strip().lower() == 'true'
-            public = request.GET.get('public', 'false').strip().lower() == 'true'
+            user_list = [user.strip() for user in request.GET.get('user_list', 'false').split(',')]
+            group_list = [group.strip() for group in request.GET.get('group_list', 'false').split(',')]
             install_embedded_resources = request.GET.get('install_embedded_resources', 'false').strip().lower() == 'true'
         else:  # if content_type == 'application/json'
 
@@ -103,7 +105,8 @@ class ResourceCollection(Resource):
 
             install_embedded_resources = normalize_boolean_param(request, 'install_embedded_resources', data.get('install_embedded_resources', False))
             force_create = data.get('force_create', False)
-            public = request.GET.get('public', 'false').strip().lower() == 'true'
+            user_list = [user.strip() for user in request.GET.get('user_list', 'false').split(',')]
+            group_list = [group.strip() for group in request.GET.get('group_list', 'false').split(',')]
             templateURL = data.get('url')
             market_endpoint = data.get('market_endpoint', None)
             headers = data.get('headers', {})
@@ -147,7 +150,7 @@ class ResourceCollection(Resource):
 
                 return build_error_response(request, 400, _('The file downloaded from the marketplace is not a zip file'))
 
-        if public and not request.user.is_superuser:
+        if user_list[0] == '*' and not request.user.is_superuser:
             return build_error_response(request, 403, _('You are not allowed to make resources publicly available to all users'))
 
         try:
@@ -159,8 +162,17 @@ class ResourceCollection(Resource):
             elif not added:
                 status_code = 200
 
-            if public:
+            if user_list[0] == '*':
                 install_resource_to_all_users(executor_user=request.user, file_contents=file_contents)
+            else:
+                users = User.objects.filter(username__in = user_list)
+                groups = Group.objects.filter(name__in = group_list)
+
+                for user in users:
+                    install_resource_to_user(user, file_contents=file_contents, templateURL=templateURL)
+
+                for group in groups:
+                    install_resource_to_group(group, file_contents=file_contents, templateURL=templateURL)
 
         except zipfile.BadZipfile as e:
 

--- a/src/wirecloud/platform/localcatalogue/views.py
+++ b/src/wirecloud/platform/localcatalogue/views.py
@@ -75,6 +75,7 @@ class ResourceCollection(Resource):
         if content_type == 'multipart/form-data':
             force_create = request.POST.get('force_create', 'false').strip().lower() == 'true'
             user_list = [user.strip() for user in request.POST.get('user_list', 'false').split(',')]
+            group_list = [group.strip() for group in request.GET.get('group_list', 'false').split(',')]
             install_embedded_resources = request.POST.get('install_embedded_resources', 'false').strip().lower() == 'true'
             if 'file' not in request.FILES:
                 return build_error_response(request, 400, _('Missing component file in the request'))
@@ -209,7 +210,7 @@ class ResourceCollection(Resource):
                     resource_file = BytesIO(file_contents.read(embedded_resource['src']))
 
                     extra_resource_contents = WgtFile(resource_file)
-                    if public:
+                    if user_list[0] == '*':
                         extra_resource_added, extra_resource = install_resource_to_user(request.user, file_contents=extra_resource_contents, raise_conflicts=False)
                     else:
                         extra_resource_added, extra_resource = install_resource_to_user(request.user, file_contents=extra_resource_contents, raise_conflicts=False)

--- a/src/wirecloud/platform/tests/rest_api.py
+++ b/src/wirecloud/platform/tests/rest_api.py
@@ -3404,7 +3404,7 @@ class ResourceManagementAPI(WirecloudTestCase, TransactionTestCase):
 
     def test_resource_collection_post_public(self):
 
-        url = reverse('wirecloud.resource_collection') + '?user_list=*'
+        url = reverse('wirecloud.resource_collection') + '?public=true'
 
         # Authenticate
         self.client.login(username='admin', password='admin')

--- a/src/wirecloud/platform/tests/rest_api.py
+++ b/src/wirecloud/platform/tests/rest_api.py
@@ -3448,6 +3448,19 @@ class ResourceManagementAPI(WirecloudTestCase, TransactionTestCase):
         resource = CatalogueResource.objects.get(vendor= 'Wirecloud', short_name= 'Test_Selenium', version= '1.0')
         self.assertEqual(list(resource.users.values_list('username', flat=True)), ['user_with_markets','user_with_workspaces'])
 
+    def test_resource_collection_post_user_list_normuser(self):
+
+        url = reverse('wirecloud.resource_collection') + '?users=user_with_workspaces,user_with_markets'
+
+        # Authenticate
+        self.client.login(username='normuser', password='admin')
+
+        # Make the request
+        with open(os.path.join(self.shared_test_data_dir, 'Wirecloud_Test_Selenium_1.0.wgt'), 'rb') as f:
+            response = self.client.post(url, f.read(), content_type="application/octet-stream", HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 403)
+        self.assertRaises(CatalogueResource.DoesNotExist, CatalogueResource.objects.get, vendor='Wirecloud', short_name='Test_Selenium', version='1.0')
+
     def test_resource_collection_post_user_list_empty(self):
         url = reverse('wirecloud.resource_collection') + '?users='
 
@@ -3477,6 +3490,50 @@ class ResourceManagementAPI(WirecloudTestCase, TransactionTestCase):
         resource = CatalogueResource.objects.get(vendor= 'Wirecloud', short_name= 'Test_Selenium', version= '1.0')
         self.assertEqual(list(resource.users.values_list('username', flat=True)), [])
         self.assertEqual(list(resource.groups.values_list('name', flat=True)), ['org'])
+
+    def test_resource_collection_post_group_normuser(self):
+
+        url = reverse('wirecloud.resource_collection') + '?groups=normusers'
+
+        # Authenticate
+        self.client.login(username='user_with_workspaces', password='admin')
+
+        # Make the request
+        with open(os.path.join(self.shared_test_data_dir, 'Wirecloud_Test_Selenium_1.0.wgt'), 'rb') as f:
+            response = self.client.post(url, f.read(), content_type="application/octet-stream", HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 403)
+
+        self.assertRaises(CatalogueResource.DoesNotExist, CatalogueResource.objects.get, vendor='Wirecloud', short_name='Test_Selenium', version='1.0')
+
+    def test_resource_collection_post_org_by_owner(self):
+
+        url = reverse('wirecloud.resource_collection') + '?groups=org'
+
+        # Authenticate
+        self.client.login(username='user_with_workspaces', password='admin')
+
+        # Make the request
+        with open(os.path.join(self.shared_test_data_dir, 'Wirecloud_Test_Selenium_1.0.wgt'), 'rb') as f:
+            response = self.client.post(url, f.read(), content_type="application/octet-stream", HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 200)
+
+        resource = CatalogueResource.objects.get(vendor= 'Wirecloud', short_name= 'Test_Selenium', version= '1.0')
+        self.assertEqual(list(resource.users.values_list('username', flat=True)), [])
+        self.assertEqual(list(resource.groups.values_list('name', flat=True)), ['org'])
+
+    def test_resource_collection_post_org_by_member(self):
+
+        url = reverse('wirecloud.resource_collection') + '?groups=org'
+
+        # Authenticate
+        self.client.login(username='normuser', password='admin')
+
+        # Make the request
+        with open(os.path.join(self.shared_test_data_dir, 'Wirecloud_Test_Selenium_1.0.wgt'), 'rb') as f:
+            response = self.client.post(url, f.read(), content_type="application/octet-stream", HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 403)
+
+        self.assertRaises(CatalogueResource.DoesNotExist, CatalogueResource.objects.get, vendor='Wirecloud', short_name='Test_Selenium', version='1.0')
 
     def test_resource_collection_post_group_list_empty(self):
         url = reverse('wirecloud.resource_collection') + '?groups='

--- a/src/wirecloud/platform/tests/rest_api.py
+++ b/src/wirecloud/platform/tests/rest_api.py
@@ -3420,7 +3420,7 @@ class ResourceManagementAPI(WirecloudTestCase, TransactionTestCase):
 
     def test_resource_collection_post_public_normuser(self):
 
-        url = reverse('wirecloud.resource_collection') + '?user_list=*'
+        url = reverse('wirecloud.resource_collection') + '?public=true'
 
         # Authenticate
         self.client.login(username='normuser', password='admin')
@@ -3434,7 +3434,7 @@ class ResourceManagementAPI(WirecloudTestCase, TransactionTestCase):
 
     def test_resource_collection_post_user_list(self):
 
-        url = reverse('wirecloud.resource_collection') + '?user_list=user_with_workspaces,user_with_markets'
+        url = reverse('wirecloud.resource_collection') + '?users=user_with_workspaces,user_with_markets'
 
         # Authenticate
         self.client.login(username='admin', password='admin')
@@ -3448,7 +3448,7 @@ class ResourceManagementAPI(WirecloudTestCase, TransactionTestCase):
         self.assertEqual(list(resource.users.values_list('username', flat=True)), ['admin','user_with_markets','user_with_workspaces'])
 
     def test_resource_collection_post_user_list_empty(self):
-        url = reverse('wirecloud.resource_collection') + '?user_list='
+        url = reverse('wirecloud.resource_collection') + '?users='
 
         # Authenticate
         self.client.login(username='admin', password='admin')
@@ -3468,7 +3468,7 @@ class ResourceManagementAPI(WirecloudTestCase, TransactionTestCase):
         usr2 = User.objects.get(username='user_with_workspaces')
         usr1.groups.add(grp1)
         usr2.groups.add(grp1)
-        url = reverse('wirecloud.resource_collection') + '?group_list=grp1'
+        url = reverse('wirecloud.resource_collection') + '?groups=grp1'
 
         # Authenticate
         self.client.login(username='admin', password='admin')
@@ -3483,7 +3483,7 @@ class ResourceManagementAPI(WirecloudTestCase, TransactionTestCase):
         self.assertEqual(list(resource.groups.values_list('name', flat=True)), ['grp1'])
 
     def test_resource_collection_post_group_list_empty(self):
-        url = reverse('wirecloud.resource_collection') + '?group_list='
+        url = reverse('wirecloud.resource_collection') + '?groups='
 
         # Authenticate
         self.client.login(username='admin', password='admin')

--- a/src/wirecloud/platform/tests/rest_api.py
+++ b/src/wirecloud/platform/tests/rest_api.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2013-2017 CoNWeT Lab., Universidad Politécnica de Madrid
+# Copyright (c) 2019 Future Internet Consulting and Development Solutions S.L.
 
 # This file is part of Wirecloud.
 
@@ -3416,7 +3417,7 @@ class ResourceManagementAPI(WirecloudTestCase, TransactionTestCase):
 
         resource = CatalogueResource.objects.get(vendor='Wirecloud', short_name='Test_Selenium', version='1.0')
         self.assertTrue(resource.public)
-        self.assertEqual(list(resource.users.values_list('username', flat=True)), ['admin'])
+        self.assertEqual(list(resource.users.values_list('username', flat=True)), [])
 
     def test_resource_collection_post_public_normuser(self):
 
@@ -3442,10 +3443,10 @@ class ResourceManagementAPI(WirecloudTestCase, TransactionTestCase):
         # Make the request
         with open(os.path.join(self.shared_test_data_dir, 'Wirecloud_Test_Selenium_1.0.wgt'), 'rb') as f:
             response = self.client.post(url, f.read(), content_type="application/octet-stream", HTTP_ACCEPT='application/json')
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
 
         resource = CatalogueResource.objects.get(vendor= 'Wirecloud', short_name= 'Test_Selenium', version= '1.0')
-        self.assertEqual(list(resource.users.values_list('username', flat=True)), ['admin','user_with_markets','user_with_workspaces'])
+        self.assertEqual(list(resource.users.values_list('username', flat=True)), ['user_with_markets','user_with_workspaces'])
 
     def test_resource_collection_post_user_list_empty(self):
         url = reverse('wirecloud.resource_collection') + '?users='
@@ -3463,12 +3464,7 @@ class ResourceManagementAPI(WirecloudTestCase, TransactionTestCase):
 
     def test_resource_collection_post_group_list(self):
 
-        grp1 = Group.objects.create(name='grp1')
-        usr1 = User.objects.get(username='user_with_markets')
-        usr2 = User.objects.get(username='user_with_workspaces')
-        usr1.groups.add(grp1)
-        usr2.groups.add(grp1)
-        url = reverse('wirecloud.resource_collection') + '?groups=grp1'
+        url = reverse('wirecloud.resource_collection') + '?groups=org'
 
         # Authenticate
         self.client.login(username='admin', password='admin')
@@ -3476,11 +3472,11 @@ class ResourceManagementAPI(WirecloudTestCase, TransactionTestCase):
         # Make the request
         with open(os.path.join(self.shared_test_data_dir, 'Wirecloud_Test_Selenium_1.0.wgt'), 'rb') as f:
             response = self.client.post(url, f.read(), content_type="application/octet-stream", HTTP_ACCEPT='application/json')
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
 
         resource = CatalogueResource.objects.get(vendor= 'Wirecloud', short_name= 'Test_Selenium', version= '1.0')
-        self.assertEqual(list(resource.users.values_list('username', flat=True)), ['admin'])
-        self.assertEqual(list(resource.groups.values_list('name', flat=True)), ['grp1'])
+        self.assertEqual(list(resource.users.values_list('username', flat=True)), [])
+        self.assertEqual(list(resource.groups.values_list('name', flat=True)), ['org'])
 
     def test_resource_collection_post_group_list_empty(self):
         url = reverse('wirecloud.resource_collection') + '?groups='

--- a/src/wirecloud/platform/workspace/tests.py
+++ b/src/wirecloud/platform/workspace/tests.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2012-2017 CoNWeT Lab., Universidad Politécnica de Madrid
+# Copyright (c) 2019 Future Internet Consulting and Development Solutions S.L.
 
 # This file is part of Wirecloud.
 

--- a/src/wirecloud/platform/workspace/utils.py
+++ b/src/wirecloud/platform/workspace/utils.py
@@ -44,7 +44,7 @@ from wirecloud.commons.utils.urlify import URLify
 from wirecloud.commons.utils.wgt import WgtFile
 from wirecloud.platform.context.utils import get_context_values
 from wirecloud.platform.iwidget.utils import parse_value_from_text
-from wirecloud.platform.localcatalogue.utils import install_resource_to_user
+from wirecloud.platform.localcatalogue.utils import install_component
 from wirecloud.platform.preferences.views import get_workspace_preference_values, get_tab_preference_values, update_workspace_preferences
 from wirecloud.platform.models import IWidget, Tab, UserWorkspace, Workspace
 from wirecloud.platform.workspace.managers import get_workspace_managers
@@ -621,7 +621,7 @@ def create_workspace(owner, f=None, mashup=None, new_name=None, new_title=None, 
                 resource_file = BytesIO(wgt.read(embedded_resource['src']))
 
             extra_resource_contents = WgtFile(resource_file)
-            install_resource_to_user(owner, file_contents=extra_resource_contents)
+            install_component(extra_resource_contents, executor_user=owner, users=[owner])
     else:
         values = mashup.split('/', 3)
         if len(values) != 3:


### PR DESCRIPTION
This PR uses the code provided on PR #214 as base for adding support for the `users` and `groups` options when installing resources into WireCloud.