### PR TITLE
Update fiware authentication backed 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: precise
+dist: xenial
 language: python
 cache: pip
 sudo: false
@@ -10,32 +10,28 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
+services:
+    - postgresql
+    - docker
+    - xvfb
 
 matrix:
     include:
         - python: "3.6"
-          dist: trusty
-          services:
-              - docker
           env:
               - TEST_SUITE=elasticsearch
               - DJANGO_VERSION=1.11
         - python: "3.6"
-          dist: trusty
-          services:
-              - docker
           env:
               - TEST_SUITE=solr
               - DJANGO_VERSION=1.11
         - node_js: "lts/*"
-          dist: trusty
           language: node_js
           python: ""
           addons:
               firefox: "45.0"
           env: TEST_SUITE=js_unittests
         - node_js: "lts/*"
-          dist: trusty
           language: node_js
           python: ""
           addons:
@@ -43,9 +39,6 @@ matrix:
           env: TEST_SUITE=js_unittests
         - addons:
               firefox: "60.2.2esr"
-          dist: trusty
-          services:
-              - docker
           env:
               - TEST_SUITE=selenium
               - DJANGO_VERSION=1.11

--- a/src/ci_scripts/travis.sh
+++ b/src/ci_scripts/travis.sh
@@ -14,7 +14,7 @@ elif [ "${TEST_SUITE}" == "solr" ]; then
 elif [ "${TEST_SUITE}" == "selenium" ]; then
     FLAGS="postgres django${DJANGO_VERSION} firefox-local elasticsearch selenium"
 else
-    FLAGS="sqlite3 django${DJANGO_VERSION} unittest"
+    FLAGS="postgres django${DJANGO_VERSION} unittest"
 fi
 
 

--- a/src/ci_scripts/travis_before_script.sh
+++ b/src/ci_scripts/travis_before_script.sh
@@ -1,9 +1,3 @@
-if [ "${TEST_SUITE}" == "js_unittests" ] || [ "${TEST_SUITE}" == "selenium" ]; then
-    export DISPLAY=:99.0
-    sh -e /etc/init.d/xvfb start
-    sleep 3 # give xvfb some time to start
-fi
-
 if [ "${TEST_SUITE}" == "elasticsearch" ] || [ "${TEST_SUITE}" == "selenium" ]; then
     export INDEX_URI=http://localhost:9200
     docker run -p 9200:9200 --rm -d elasticsearch:2.4

--- a/src/setup.py
+++ b/src/setup.py
@@ -186,7 +186,7 @@ setup(
         'user-agents',
         'regex',
         'markdown',
-        'django-haystack>=2.6.0',
+        'django-haystack>=2.6.0,<2.8.0',
         'whoosh>=2.7.2',
         'pycrypto',
         'pyScss>=1.3.4,<2.0',

--- a/src/wirecloud/commons/tests/admin_commands.py
+++ b/src/wirecloud/commons/tests/admin_commands.py
@@ -184,6 +184,8 @@ class ConvertCommandTestCase(WirecloudTestCase, TestCase):
 
         shutil.rmtree(cls.tmp_dir, ignore_errors=True)
 
+        super(ConvertCommandTestCase, cls).tearDownClass()
+
     def setUp(self):
 
         from wirecloud.commons.commands.convert import ConvertCommand
@@ -263,6 +265,8 @@ class StartprojectCommandTestCase(WirecloudTestCase, TestCase):
     def tearDownClass(cls):
 
         shutil.rmtree(cls.tmp_dir, ignore_errors=True)
+
+        super(StartprojectCommandTestCase, cls).tearDownClass()
 
     def setUp(self):
 

--- a/src/wirecloud/fiware/proxy.py
+++ b/src/wirecloud/fiware/proxy.py
@@ -115,7 +115,7 @@ class IDMTokenProcessor(object):
             self.openstack_manager = OpenstackTokenManager(getattr(settings, 'FIWARE_CLOUD_SERVER', FIWARE_LAB_CLOUD_SERVER))
 
     def process_request(self, request):
-        headers = ['fiware-oauth-token', 'x-fi-ware-oauth-token', 'fiware-openstack-token']
+        headers = ['fiware-oauth-token', 'fiware-openstack-token']
         filtered = [header for header in headers if header in request['headers']]
 
         if len(filtered) == 0:
@@ -135,9 +135,6 @@ class IDMTokenProcessor(object):
         if 'fiware-oauth-source' in request['headers']:
             source = request['headers']['fiware-oauth-source']
             del request['headers']['fiware-oauth-source']
-        elif 'x-fi-ware-oauth-source' in request['headers']:
-            source = request['headers']['x-fi-ware-oauth-source']
-            del request['headers']['x-fi-ware-oauth-source']
 
         if source == 'user':
             token = get_access_token(request['user'], _('Current user has not an active FIWARE profile'))
@@ -150,10 +147,10 @@ class IDMTokenProcessor(object):
         else:
             raise ValidationError(_('Invalid FIWARE OAuth token source'))
 
-        if 'fiware-oauth-token' in filtered or 'x-fi-ware-oauth-token' in filtered:
-            replace_get_parameter(request, ["fiware-oauth-get-parameter", "x-fi-ware-oauth-get-parameter"], token)
-            replace_header_name(request, ["fiware-oauth-header-name", "x-fi-ware-oauth-header-name"], token)
-            replace_body_pattern(request, ["fiware-oauth-body-pattern", "x-fi-ware-oauth-token-body-pattern"], token)
+        if 'fiware-oauth-token' in filtered:
+            replace_get_parameter(request, ["fiware-oauth-get-parameter"], token)
+            replace_header_name(request, ["fiware-oauth-header-name"], token)
+            replace_body_pattern(request, ["fiware-oauth-body-pattern"], token)
 
         if 'fiware-openstack-token' in filtered:
             replace_get_parameter(request, ["fiware-openstack-get-parameter"], openstacktoken)

--- a/src/wirecloud/fiware/proxy.py
+++ b/src/wirecloud/fiware/proxy.py
@@ -49,10 +49,8 @@ def get_access_token(user, error_msg):
         if oauth_info.access_token is None:
             raise Exception
 
-        # Refresh the token if the token has been expired or the token expires
-        # in less than 30 seconds
-        # Also refresh the token if expires_on information does not exist yet
-        if time.time() > oauth_info.extra_data.get('expires_on', 0) - 30:
+        # Refresh the token if expired
+        if oauth_info.access_token_expired():
             oauth_info.refresh_token(STRATEGY)
 
         return oauth_info.access_token

--- a/src/wirecloud/fiware/social_auth_backend.py
+++ b/src/wirecloud/fiware/social_auth_backend.py
@@ -83,16 +83,8 @@ class FIWAREOAuth2(BaseOAuth2):
     EXTRA_DATA = [
         ('username', 'username'),
         ('refresh_token', 'refresh_token'),
-        ('expires_in', 'expires_in'),
+        ('expires_in', 'expires'),
     ]
-
-    def extra_data(self, user, uid, response, details=None, *args, **kwargs):
-        """Return access_token and extra defined names to store in
-        extra_data field"""
-        data = super(FIWAREOAuth2, self).extra_data(user, uid, response, details, *args, **kwargs)
-        # Save the expiration time
-        data['expires_on'] = time.time() + data['expires_in']
-        return data
 
     def auth_headers(self):
         token = base64.urlsafe_b64encode(('{0}:{1}'.format(*self.get_key_and_secret()).encode())).decode()
@@ -102,8 +94,6 @@ class FIWAREOAuth2(BaseOAuth2):
 
     def refresh_token(self, token, *args, **kwargs):
         data = super(FIWAREOAuth2, self).refresh_token(token, *args, **kwargs)
-        # Save the expiration time
-        data['expires_on'] = time.time() + data['expires_in']
         data['openstack_token'] = None
         return data
 

--- a/src/wirecloud/fiware/static/js/ObjectStorage/OpenStackManager.js
+++ b/src/wirecloud/fiware/static/js/ObjectStorage/OpenStackManager.js
@@ -69,8 +69,8 @@
                 contentType: 'application/json',
                 requestHeaders: {
                     'Accept': 'application/json',
-                    'X-FI-WARE-OAuth-Token': 'true',
-                    'X-FI-WARE-OAuth-Token-Body-Pattern': '%idm_token%'
+                    'X-FIWARE-OAuth-Token': 'true',
+                    'X-FIWARE-OAuth-Token-Body-Pattern': '%idm_token%'
                 },
                 postBody: JSON.stringify({
                     "auth": {

--- a/src/wirecloud/fiware/tests/proxy.py
+++ b/src/wirecloud/fiware/tests/proxy.py
@@ -142,6 +142,7 @@ class ProxyTestCase(WirecloudTestCase, TestCase):
         return validator
 
     def check_proxy_request(self, validator=lambda response: True, path='/path', refresh=False, **kwargs):
+        self.admin_mock.social_auth.get().access_token_expired.return_value = refresh
         request = self.prepare_request_mock(**kwargs)
         response = proxy_request(request=request, protocol='http', domain='example.com', path=path)
         validator(response)
@@ -319,22 +320,6 @@ class ProxyTestCase(WirecloudTestCase, TestCase):
 
     def test_fiware_token_is_refreshed_when_expired(self):
 
-        self.admin_mock.social_auth.get(provider='fiware').extra_data['expires_on'] = time.time()
-        self.network._servers['http']['example.com'].add_response('POST', '/path', self.echo_headers_response)
-
-        def validator(response):
-            self.assertEqual(response.status_code, 200)
-            headers = json.loads(self.read_response(response))
-            self.assertIn('X-Auth-Token', headers)
-            self.assertEqual(headers['X-Auth-Token'], TEST_TOKEN)
-
-        self.check_proxy_request(validator=validator, data='{}', extra_headers={
-            "HTTP_FIWARE_OAUTH_HEADER_NAME": 'X-Auth-Token',
-        }, refresh=True)
-
-    def test_fiware_token_is_refreshed_missing_expires_on(self):
-
-        del self.admin_mock.social_auth.get(provider='fiware').extra_data['expires_on']
         self.network._servers['http']['example.com'].add_response('POST', '/path', self.echo_headers_response)
 
         def validator(response):

--- a/src/wirecloud/fiware/tests/proxy.py
+++ b/src/wirecloud/fiware/tests/proxy.py
@@ -96,7 +96,7 @@ class ProxyTestCase(WirecloudTestCase, TestCase):
         else:
             return response.content.decode('utf-8')
 
-    def prepare_request_mock(self, data=None, referer='http://localhost/user_with_workspaces/public-workspace', user=None, extra_headers={}, GET='', use_deprecated_code=False):
+    def prepare_request_mock(self, data=None, referer='http://localhost/user_with_workspaces/public-workspace', user=None, extra_headers={}, GET=''):
 
         request = Mock()
         request.get_host.return_value = 'localhost'
@@ -124,11 +124,7 @@ class ProxyTestCase(WirecloudTestCase, TestCase):
         else:
             request.method = 'GET'
 
-        if use_deprecated_code:
-            request.META['HTTP_X_FI_WARE_OAUTH_TOKEN'] = 'true'
-            extra_headers = {self.deprecation_mapping[key]: value for key, value in extra_headers.items()}
-        else:
-            request.META['HTTP_FIWARE_OAUTH_TOKEN'] = 'true'
+        request.META['HTTP_FIWARE_OAUTH_TOKEN'] = 'true'
 
         request.META.update(extra_headers)
         if user is None:
@@ -138,13 +134,6 @@ class ProxyTestCase(WirecloudTestCase, TestCase):
 
         return request
 
-    deprecation_mapping = {
-        "HTTP_FIWARE_OAUTH_BODY_PATTERN": "HTTP_X_FI_WARE_OAUTH_TOKEN_BODY_PATTERN",
-        "HTTP_FIWARE_OAUTH_GET_PARAMETER": "HTTP_X_FI_WARE_OAUTH_GET_PARAMETER",
-        "HTTP_FIWARE_OAUTH_HEADER_NAME": "HTTP_X_FI_WARE_OAUTH_HEADER_NAME",
-        "HTTP_FIWARE_OAUTH_SOURCE": "HTTP_X_FI_WARE_OAUTH_SOURCE",
-    }
-
     def invalid_request_validator(self):
         def validator(response):
             self.assertEqual(response.status_code, 422)
@@ -153,19 +142,11 @@ class ProxyTestCase(WirecloudTestCase, TestCase):
         return validator
 
     def check_proxy_request(self, validator=lambda response: True, path='/path', refresh=False, **kwargs):
-        request = self.prepare_request_mock(use_deprecated_code=False, **kwargs)
+        request = self.prepare_request_mock(**kwargs)
         response = proxy_request(request=request, protocol='http', domain='example.com', path=path)
         validator(response)
 
-        request = self.prepare_request_mock(use_deprecated_code=True, **kwargs)
-        response = proxy_request(request=request, protocol='http', domain='example.com', path=path)
-        validator(response)
-
-        if refresh:
-            # We do two calls to the API
-            self.assertEqual(self.admin_mock.social_auth.get(provider='fiware').refresh_token.call_count, 2)
-        else:
-            self.assertEqual(self.admin_mock.social_auth.get(provider='fiware').refresh_token.call_count, 0)
+        self.assertEqual(self.admin_mock.social_auth.get(provider='fiware').refresh_token.call_count, 1 if refresh else 0)
 
     def test_normal_request(self):
         request = self.prepare_request_mock()

--- a/src/wirecloud/fiware/tests/social_backend.py
+++ b/src/wirecloud/fiware/tests/social_backend.py
@@ -37,14 +37,14 @@ class BasicClass(object):
         return {
             "access_token": "access_token",
             "refresh_token": "refresh_token",
-            "expires_in": 3600
+            "expires": 3600
         }
 
     def refresh_token(self, token, *args, **kwargs):
         return {
             "access_token": "new_access_token",
             "refresh_token": "new_refresh_token",
-            "expires_in": 3600
+            "expires": 3600
         }
 
     @classmethod
@@ -180,8 +180,7 @@ class TestSocialAuthBackend(WirecloudTestCase, TestCase):
         self.assertEqual(data, {
             "access_token": "access_token",
             "refresh_token": "refresh_token",
-            "expires_in": 3600,
-            "expires_on": 13600
+            "expires": 3600,
         })
 
     def test_get_user_details_old_version(self):
@@ -233,8 +232,7 @@ class TestSocialAuthBackend(WirecloudTestCase, TestCase):
         self.assertEqual(data, {
             "access_token": "new_access_token",
             "refresh_token": "new_refresh_token",
-            "expires_in": 3600,
-            "expires_on": 13600,
+            "expires": 3600,
             "openstack_token": None
         })
 


### PR DESCRIPTION
Newer version of social auth provides support for checking whether a token has expired or not. This PR requests mainly focuses on removing custom code used by WireCloud to provide this same feature. This PR also remove deprecated support for the `X-FI-WARE-*` headers used by the authentication backend.