### PR TITLE
Use pymdown extensions to be able to use GFM on the mkdocs documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,11 +29,20 @@ pages:
         - 'Translations': 'development/platform/translation.md'
 
 markdown_extensions:
-    - markdown_github.headerid
-    - markdown_github.superfences
-    - markdown_github.magiclink
+    - markdown.extensions.tables
+    - pymdownx.betterem
+    - pymdownx.tilde
+        subscript: False
+    - pymdownx.superfences
+    - pymdownx.magiclink:
+        repo_url_shortener: True
+        repo_url_shorthand: True
+        provider: "github"
+        user: "Wirecloud"
+        repo: "wirecloud"
+    - pymdownx.tasklist
     - codehilite:
         guess_lang: False
     - toc:
         permalink: True
-        separator: "."
+        separator: "-"

--- a/mkdocs_requirements.txt
+++ b/mkdocs_requirements.txt
@@ -1,1 +1,1 @@
-wirecloud-markdown-github
+pymdown-extensions


### PR DESCRIPTION
Current mkdocs documentation is build using a custom python module providing early stage version of the pymdown extensions. Now that those extensions are published on pypy, this PR updates mkdocs/RTD configuration to use those extensions directly instead.