### PR TITLE
Make username and avatar clickable to open user menu

### DIFF
--- a/src/.eslintrc-jasmine
+++ b/src/.eslintrc-jasmine
@@ -1,6 +1,0 @@
-{
-    "extends": ".eslintrc",
-    "env": {
-        "jasmine": true
-    }
-}

--- a/src/GruntFile.js
+++ b/src/GruntFile.js
@@ -164,7 +164,7 @@ module.exports = function (grunt) {
             },
             specs: {
                 options: {
-                    configFile: ".eslintrc-jasmine",
+                    configFile: "js_tests/.eslintrc",
                 },
                 src: 'js_tests/**/*Spec.js',
             }

--- a/src/js_tests/.eslintrc
+++ b/src/js_tests/.eslintrc
@@ -1,0 +1,6 @@
+{
+    "extends": "../.eslintrc",
+    "env": {
+        "jasmine": true
+    }
+}

--- a/src/js_tests/styledelements/GUIBuilderSpec.js
+++ b/src/js_tests/styledelements/GUIBuilderSpec.js
@@ -149,7 +149,6 @@
                     expect(result.elements.length).toBe(1);
                     var child = result.elements[0];
                     check_final_element(child, label, rendered_value_options);
-
                 });
 
                 it("should ignore malformed json options", function () {
@@ -306,6 +305,36 @@
             // Remove xhtml namespace
             var outerHTML = result.elements[0].outerHTML.replace(' xmlns="http://www.w3.org/1999/xhtml"', '');
             expect(outerHTML).toBe('<div><div class="se-btn" tabindex="0"><span>Save</span></div></div>');
+        });
+
+        it("should allow to nest template elements with function context and json option", function () {
+            var builder = new StyledElements.GUIBuilder();
+            var template = '<div><t:usermenu plain="true"><t:avatar/><span><t:username/></span><t:test>{"class": "fa fa-caret-down"}</t:test></t:usermenu></div>';
+            var context = {
+                avatar: document.createElement('img'),
+                username: "John Doe",
+                usermenu: (options) => {
+                    this.user_button = new StyledElements.PopupButton(options);
+                    return this.user_button;
+                },
+                test: (options) => {
+                    var testDiv = document.createElement('div');
+                    testDiv.innerHTML = 'a';
+                    if (options != null && 'class' in options) {
+                        testDiv.className = options.class;
+                    }
+                    return testDiv;
+                }
+            };
+            var result = builder.parse(builder.DEFAULT_OPENING + template + builder.DEFAULT_CLOSING, context);
+            expect(result.elements.length).toBe(1);
+            expect(result.elements[0].nodeType).toBe(Node.ELEMENT_NODE);
+            expect(result.elements[0].childNodes.length).toBe(1);
+            expect(result.elements[0].childNodes[0].nodeType).toBe(Node.ELEMENT_NODE);
+            expect(result.elements[0].childNodes[0].childNodes.length).toBe(3);
+            // Remove xhtml namespace
+            var outerHTML = result.elements[0].outerHTML.replace(' xmlns="http://www.w3.org/1999/xhtml"', '');
+            expect(outerHTML).toBe('<div><div class="se-btn plain" tabindex="0"><img /><span>John Doe</span><div class="fa fa-caret-down">a</div></div></div>');
         });
     });
 

--- a/src/js_tests/styledelements/GUIBuilderSpec.js
+++ b/src/js_tests/styledelements/GUIBuilderSpec.js
@@ -334,7 +334,9 @@
             expect(result.elements[0].childNodes[0].childNodes.length).toBe(3);
             // Remove xhtml namespace
             var outerHTML = result.elements[0].outerHTML.replace(' xmlns="http://www.w3.org/1999/xhtml"', '');
-            expect(outerHTML).toBe('<div><div class="se-btn plain" tabindex="0"><img /><span>John Doe</span><div class="fa fa-caret-down">a</div></div></div>');
+            // "Normalize" empty tags to work with different HTML engines (Firefox 45 vs Firefox 60)
+            outerHTML = outerHTML.replace(/ \/>/g, "/>");
+            expect(outerHTML).toBe('<div><div class="se-btn plain" tabindex="0"><img/><span>John Doe</span><div class="fa fa-caret-down">a</div></div></div>');
         });
     });
 

--- a/src/wirecloud/commons/static/js/StyledElements/GUIBuilder.js
+++ b/src/wirecloud/commons/static/js/StyledElements/GUIBuilder.js
@@ -107,6 +107,16 @@
                 children[i] = component;
             } else if (child.namespaceURI === TEMPLATE_NAMESPACE) {
                 children[i] = processTComponent(child, tcomponents, context);
+
+                if (child.childNodes.length > 0) {
+                    // TODO improve, generalize?
+                    processTree(builder, child, tcomponents, context);
+                    var el = children[i].get();
+                    var childLength = child.childNodes.length;
+                    for (var ci = 0; ci < childLength; ci++) {
+                        el.appendChild(child.childNodes[0]);
+                    }
+                }
             } else {
                 processTree(builder, child, tcomponents, context);
             }

--- a/src/wirecloud/commons/static/js/StyledElements/GUIBuilder.js
+++ b/src/wirecloud/commons/static/js/StyledElements/GUIBuilder.js
@@ -26,7 +26,7 @@
 
     "use strict";
 
-    var GUIBuilder, processTComponent, processTree, processRoot, extractOptions, extractOptionsFromAttributes, populateContainer, NAMESPACE, TEMPLATE_NAMESPACE;
+    var GUIBuilder, processTComponent, processChildren, processTree, processRoot, extractOptionsFromTextNode, extractOptions, extractOptionsFromAttributes, populateContainer, NAMESPACE, TEMPLATE_NAMESPACE;
 
     NAMESPACE = 'http://wirecloud.conwet.fi.upm.es/StyledElements';
     TEMPLATE_NAMESPACE = 'http://wirecloud.conwet.fi.upm.es/Template';
@@ -36,16 +36,7 @@
 
         tcomponent = tcomponents[element.localName];
         if (typeof tcomponent === 'function') {
-            options = element.textContent.trim();
-            if (options !== '') {
-                try {
-                    options = JSON.parse(options);
-                } catch (e) {
-                    options = {};
-                }
-            } else {
-                options = {};
-            }
+            options = extractOptionsFromTextNode(element);
             utils.merge(options, extractOptionsFromAttributes(element));
 
             new_component = tcomponent(options, tcomponents, context);
@@ -63,6 +54,55 @@
 
         return new_component;
     };
+
+    extractOptionsFromTextNode = function (element) {
+        var options = {};
+
+        for (var i = 0; i < element.childNodes.length; i++) {
+            var curNode = element.childNodes[i];
+            // find the first non-empty text node
+            if (curNode.nodeType === Node.TEXT_NODE && !(/^\s*$/.test(curNode.nodeValue))) {
+
+                try {
+                    options = JSON.parse(curNode.nodeValue);
+                } catch (e) {
+                    options = {};
+                }
+
+                // remove element to not appear as nested element in result
+                element.removeChild(curNode);
+                break;
+            }
+        }
+
+        return options;
+    };
+
+    processChildren = function processChildren(new_element, builder, element, tcomponents, context) {
+        if (element.childNodes.length > 0) {
+            processTree(builder, element, tcomponents, context);
+
+            if (new_element !== element) {
+                if (new_element instanceof StyledElements.StyledElement) {
+                    new_element = new_element.get();
+                }
+                if (typeof new_element.appendChild !== 'function') {
+                    return;
+                }
+                // because we modify the DOM and childNodes is a live collection
+                // we cannot use a regular for loop
+                var prevChild = null;
+                while (element.firstChild !== null) {
+                    // safety check, if for some unexpected reason no modification takes place
+                    if (prevChild === element.firstChild) {
+                        break;
+                    }
+                    prevChild = element.firstChild;
+                    new_element.appendChild(element.firstChild);
+                }
+            }
+        }
+    }
 
     processTree = function processTree(builder, element, tcomponents, context) {
         var i, child, component, new_component;
@@ -85,6 +125,7 @@
                     element.insertBefore(new_component, child);
                 }
                 element.removeChild(child);
+                processChildren(new_component, builder, child, tcomponents, context);
             }  else {
                 processTree(builder, child, tcomponents, context);
             }
@@ -107,16 +148,7 @@
                 children[i] = component;
             } else if (child.namespaceURI === TEMPLATE_NAMESPACE) {
                 children[i] = processTComponent(child, tcomponents, context);
-
-                if (child.childNodes.length > 0) {
-                    // TODO improve, generalize?
-                    processTree(builder, child, tcomponents, context);
-                    var el = children[i].get();
-                    var childLength = child.childNodes.length;
-                    for (var ci = 0; ci < childLength; ci++) {
-                        el.appendChild(child.childNodes[0]);
-                    }
-                }
+                processChildren(children[i], builder, child, tcomponents, context);
             } else {
                 processTree(builder, child, tcomponents, context);
             }

--- a/src/wirecloud/defaulttheme/static/css/header.scss
+++ b/src/wirecloud/defaulttheme/static/css/header.scss
@@ -33,7 +33,7 @@
 #wirecloud_header .menu_wrapper > .menu {
     display: inline-block;
     background: #E4E6E2;
-    box-shadow: 0 3px 3px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
     padding: 0 0 0 1ex;
     vertical-align: top;
 }
@@ -46,18 +46,17 @@
 
     & .se-btn {
         opacity: 1;
-        margin-top: -2px;
+        // vertical alignment doesn't center correctly
+        margin-top: -3px;
 
-        &:hover {
-            color: lighten(#990000, 10%);
-        }
         &:active {
+            // disable default button effect
             box-shadow: none;
         }
     }
 
     & * {
-        line-height: 30px;
+        line-height: 25px;
         vertical-align: middle;
     }
 

--- a/src/wirecloud/defaulttheme/static/css/header.scss
+++ b/src/wirecloud/defaulttheme/static/css/header.scss
@@ -40,20 +40,32 @@
 
 #wc-user-menu {
     display: inline-block;
-    width: 30ex;
     height: 30px;
     line-height: 30px;
     margin: 0 1ex;
 
-    & > * {
+    & .se-btn {
+        opacity: 1;
+        margin-top: -2px;
+
+        &:hover {
+            color: lighten(#990000, 10%);
+        }
+        &:active {
+            box-shadow: none;
+        }
+    }
+
+    & * {
+        line-height: 30px;
         vertical-align: middle;
     }
 
-    & > .avatar {
+    & .avatar {
         border-radius: 2px;
     }
 
-    & > span {
+    & span {
         margin: 0px 3px;
     }
 }

--- a/src/wirecloud/defaulttheme/templates/registration/login.html
+++ b/src/wirecloud/defaulttheme/templates/registration/login.html
@@ -28,7 +28,7 @@
 
         <div id="unsupported-browser-msg" class="alert alert-error" style="display: none; text-align: left;">
             <h4>{% trans "Your browser seems to lack some required features" %}</h4>
-            <p>{% blocktrans %}We recommend you to upgrade your browser to the newest version of either <a href="https://www.mozilla.org/firefox">Firefox</a> or <a href="www.google.com/chrome">Google Chrome</a> as these are the browsers currently supported by WireCloud.{% endblocktrans %}</p>
+            <p>{% blocktrans %}We recommend you to upgrade your browser to the newest version of either <a href="https://www.mozilla.org/firefox">Firefox</a> or <a href="https://www.google.com/chrome">Google Chrome</a> as these are the browsers currently supported by WireCloud.{% endblocktrans %}</p>
         </div>
 
         <form style="text-align: left; width: 400px" id="wc-login-form" method="post">

--- a/src/wirecloud/defaulttheme/templates/wirecloud/user_menu.html
+++ b/src/wirecloud/defaulttheme/templates/wirecloud/user_menu.html
@@ -1,3 +1,3 @@
 <s:styledgui xmlns:s="http://wirecloud.conwet.fi.upm.es/StyledElements" xmlns:t="http://wirecloud.conwet.fi.upm.es/Template" xmlns="http://www.w3.org/1999/xhtml">
-    <t:avatar/><span><t:username/></span><t:usermenu plain="true" class="fa fa-caret-down" />
+    <t:usermenu plain="true"><t:avatar/><span><t:username/></span><span class="fa fa-caret-down"></span></t:usermenu>
 </s:styledgui>

--- a/src/wirecloud/defaulttheme/templates/wirecloud/views/base.html
+++ b/src/wirecloud/defaulttheme/templates/wirecloud/views/base.html
@@ -46,7 +46,7 @@
 
 <div id="unsupported-browser-msg" class="alert alert-error" style="display: none; text-align: left;">
     <h4>{% trans "Your browser seems to lack some required features" %}</h4>
-    <p>{% blocktrans %}We recommend you to upgrade your browser to the newest version of either <a href="https://www.mozilla.org/firefox">Firefox</a> or <a href="www.google.com/chrome">Google Chrome</a> as these are the browsers currently supported by WireCloud.{% endblocktrans %}</p>
+    <p>{% blocktrans %}We recommend you to upgrade your browser to the newest version of either <a href="https://www.mozilla.org/firefox">Firefox</a> or <a href="https://www.google.com/chrome">Google Chrome</a> as these are the browsers currently supported by WireCloud.{% endblocktrans %}</p>
 </div>
 
 <div class="se-vertical-layout">


### PR DESCRIPTION
In order to make it easier to open the user menu, I nested the avatar and the user name inside the usermenu button.
To support this, I extended the GUIBuilder to process node children of custom elements.

Some styling changes were also applied, to make the user area smaller (or was there a particular reason for it to be so wide?), and apply a softer shadow:
![grafik](https://user-images.githubusercontent.com/1231010/54995156-61890780-4fc6-11e9-8970-72347482d147.png)
