### PR TITLE
Drop Django 1.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 cache: pip
 sudo: false
 env:
-    - DJANGO_VERSION=1.9
     - DJANGO_VERSION=1.10
     - DJANGO_VERSION=1.11
 python:

--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -1282,7 +1282,7 @@ LOGGING['loggers']['django.security.DisallowedHost'] = {
 ```
 
 This method can be used also for disabling other `SuspiciousOperation` error mails. See the
-[Django documentation](https://docs.djangoproject.com/es/1.9/topics/logging/#django-security) for more info.
+[Django documentation](https://docs.djangoproject.com/es/1.10/topics/logging/#django-security) for more info.
 
 ### I don't remember the admin credentials. How can I recover it?
 

--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-This Installation WireCloud version 1.2 (starting from FIWARE release 7.4). Any feedback on this document is highly
+This Installation WireCloud version 1.3 (starting from FIWARE release 7.7). Any feedback on this document is highly
 welcomed, including bugs, typos or things you think should be included but are not. Please send it to the "Contact
 Person" email that appears in the [Catalogue page for this GEi][catalogue].
 
@@ -12,14 +12,13 @@ This section describes all the requirements of a basic WireCloud installation. *
 meant to be installed manually in this step, as they will be installed throughout the documentation:**
 
 -   A Database Manager (MySQL, PostgreSQL, SQLite3...)
--   Python 2.7 or python 3.4+. In any case, the following python packages must be installed:
-    -   Django 1.9-1.11
+-   Python 3.4+. In any case, the following python packages must be installed:
+    -   Django 1.10-1.11
     -   lxml 2.3.0+
     -   django-appconf 1.0.1+
     -   django_compressor 2.0+
     -   rdflib 3.2.0+
     -   requests 2.1.0+
-    -   futures 2.1.3+ (only on python 2.7)
     -   selenium 3.4+
     -   pytz
     -   django_relatives 0.3.x

--- a/src/ci_scripts/conf_scripts/django1.8-prepip.sh
+++ b/src/ci_scripts/conf_scripts/django1.8-prepip.sh
@@ -1,1 +1,0 @@
-pip install -U "Django>=1.8,<1.9"

--- a/src/ci_scripts/conf_scripts/django1.9-prepip.sh
+++ b/src/ci_scripts/conf_scripts/django1.9-prepip.sh
@@ -1,1 +1,0 @@
-pip install -U "Django>=1.9,<1.10"

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-Django<1.12,>=1.9
+Django<1.12,>=1.10
 lxml>=2.3
 django-appconf<2.0,>=1.0.1
 django_compressor<3.0,>=2.0

--- a/src/setup.py
+++ b/src/setup.py
@@ -113,7 +113,7 @@ class compiletranslations(Command):
             from django.core.management import call_command
         except:
             import pip
-            pip.main(['install', 'Django>=1.9,<1.12'])
+            pip.main(['install', 'Django>=1.10,<1.12'])
 
             from django.core.management import call_command
 
@@ -174,7 +174,7 @@ setup(
     },
     include_package_data=True,
     install_requires=(
-        'Django>=1.9,<1.12',
+        'Django>=1.10,<1.12',
         'lxml>=2.3',
         'django-appconf>=1.0.1,<2.0',
         'django_compressor>=2.0,<3.0',

--- a/src/wirecloud/platform/preferences/models.py
+++ b/src/wirecloud/platform/preferences/models.py
@@ -23,13 +23,7 @@ from django.contrib.auth.signals import user_logged_in
 from django.db import models
 from django.dispatch import receiver
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.translation import check_for_language, gettext_lazy as _
-
-try:
-    # Django 1.7+
-    from django.utils.translation import LANGUAGE_SESSION_KEY
-except:
-    LANGUAGE_SESSION_KEY = 'django_language'
+from django.utils.translation import check_for_language, gettext_lazy as _, LANGUAGE_SESSION_KEY
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
This PR removes support for Django 1.9 from WireCloud.