### PR TITLE
Use a separate ENV variable for Authentication URL is supplied

### DIFF
--- a/src/wirecloud/fiware/plugins.py
+++ b/src/wirecloud/fiware/plugins.py
@@ -158,7 +158,7 @@ class FiWarePlugin(WirecloudPlugin):
             import wirecloud.fiware.social_auth_backend
             constants["FIWARE_OFFICIAL_PORTAL"] = getattr(settings, "FIWARE_OFFICIAL_PORTAL", False)
             constants["FIWARE_IDM_SERVER"] = getattr(settings, "FIWARE_IDM_SERVER", wirecloud.fiware.social_auth_backend.FIWARE_LAB_IDM_SERVER)
-            constants["FIWARE_IDM_URL"] = getattr(settings, "FIWARE_IDM_URL", wirecloud.fiware.social_auth_backend.FIWARE_LAB_IDM_SERVER)
+            constants["FIWARE_IDM_PUBLIC_URL"] = getattr(settings, "FIWARE_IDM_PUBLIC_URL", wirecloud.fiware.social_auth_backend.FIWARE_LAB_IDM_SERVER)
 
         return constants
 
@@ -196,10 +196,10 @@ class FiWarePlugin(WirecloudPlugin):
 
         if IDM_SUPPORT_ENABLED:
             context["FIWARE_IDM_SERVER"] = getattr(settings, "FIWARE_IDM_SERVER", wirecloud.fiware.social_auth_backend.FIWARE_LAB_IDM_SERVER)
-            context["FIWARE_IDM_URL"] = getattr(settings, "FIWARE_IDM_URL", wirecloud.fiware.social_auth_backend.FIWARE_LAB_IDM_SERVER)
+            context["FIWARE_IDM_PUBLIC_URL"] = getattr(settings, "FIWARE_IDM_PUBLIC_URL", wirecloud.fiware.social_auth_backend.FIWARE_LAB_IDM_SERVER)
         else:
             context["FIWARE_IDM_SERVER"] = None
-            context["FIWARE_IDM_URL"] = None
+            context["FIWARE_IDM_PUBLIC_URL"] = None
 
         return context
 

--- a/src/wirecloud/fiware/plugins.py
+++ b/src/wirecloud/fiware/plugins.py
@@ -158,6 +158,7 @@ class FiWarePlugin(WirecloudPlugin):
             import wirecloud.fiware.social_auth_backend
             constants["FIWARE_OFFICIAL_PORTAL"] = getattr(settings, "FIWARE_OFFICIAL_PORTAL", False)
             constants["FIWARE_IDM_SERVER"] = getattr(settings, "FIWARE_IDM_SERVER", wirecloud.fiware.social_auth_backend.FIWARE_LAB_IDM_SERVER)
+            constants["FIWARE_IDM_URL"] = getattr(settings, "FIWARE_IDM_URL", wirecloud.fiware.social_auth_backend.FIWARE_LAB_IDM_SERVER)
 
         return constants
 
@@ -195,8 +196,10 @@ class FiWarePlugin(WirecloudPlugin):
 
         if IDM_SUPPORT_ENABLED:
             context["FIWARE_IDM_SERVER"] = getattr(settings, "FIWARE_IDM_SERVER", wirecloud.fiware.social_auth_backend.FIWARE_LAB_IDM_SERVER)
+            context["FIWARE_IDM_URL"] = getattr(settings, "FIWARE_IDM_URL", wirecloud.fiware.social_auth_backend.FIWARE_LAB_IDM_SERVER)
         else:
             context["FIWARE_IDM_SERVER"] = None
+            context["FIWARE_IDM_URL"] = None
 
         return context
 

--- a/src/wirecloud/fiware/social_auth_backend.py
+++ b/src/wirecloud/fiware/social_auth_backend.py
@@ -74,7 +74,12 @@ class FIWAREOAuth2(BaseOAuth2):
     """FIWARE IdM OAuth authentication backend"""
     name = 'fiware'
     ID_KEY = 'username'
-    AUTHORIZATION_URL = urljoin(getattr(settings, 'FIWARE_IDM_SERVER', FIWARE_LAB_IDM_SERVER), FIWARE_AUTHORIZATION_ENDPOINT)
+
+    if hasattr(settings, 'FIWARE_IDM_URL'):
+        AUTHORIZATION_URL = urljoin(getattr(settings, 'FIWARE_IDM_URL', FIWARE_LAB_IDM_SERVER), FIWARE_AUTHORIZATION_ENDPOINT)
+    else:
+        AUTHORIZATION_URL = urljoin(getattr(settings, 'FIWARE_IDM_SERVER', FIWARE_LAB_IDM_SERVER), FIWARE_AUTHORIZATION_ENDPOINT)
+    
     ACCESS_TOKEN_URL = urljoin(getattr(settings, 'FIWARE_IDM_SERVER', FIWARE_LAB_IDM_SERVER), FIWARE_ACCESS_TOKEN_ENDPOINT)
     USER_DATA_URL = urljoin(getattr(settings, 'FIWARE_IDM_SERVER', FIWARE_LAB_IDM_SERVER), FIWARE_USER_DATA_ENDPOINT)
     REDIRECT_STATE = False

--- a/src/wirecloud/fiware/social_auth_backend.py
+++ b/src/wirecloud/fiware/social_auth_backend.py
@@ -75,8 +75,8 @@ class FIWAREOAuth2(BaseOAuth2):
     name = 'fiware'
     ID_KEY = 'username'
 
-    if hasattr(settings, 'FIWARE_IDM_URL'):
-        AUTHORIZATION_URL = urljoin(getattr(settings, 'FIWARE_IDM_URL', FIWARE_LAB_IDM_SERVER), FIWARE_AUTHORIZATION_ENDPOINT)
+    if hasattr(settings, 'FIWARE_IDM_PUBLIC_URL'):
+        AUTHORIZATION_URL = urljoin(getattr(settings, 'FIWARE_IDM_PUBLIC_URL', FIWARE_LAB_IDM_SERVER), FIWARE_AUTHORIZATION_ENDPOINT)
     else:
         AUTHORIZATION_URL = urljoin(getattr(settings, 'FIWARE_IDM_SERVER', FIWARE_LAB_IDM_SERVER), FIWARE_AUTHORIZATION_ENDPOINT)
     

--- a/src/wirecloud/fiware/tests/social_backend.py
+++ b/src/wirecloud/fiware/tests/social_backend.py
@@ -307,6 +307,7 @@ class TestSocialAuthBackend(WirecloudTestCase, TestCase):
         self.assertIn('FIWARE_PORTALS', constants)
         self.assertIn('FIWARE_OFFICIAL_PORTAL', constants)
         self.assertIn('FIWARE_IDM_SERVER', constants)
+        self.assertIn('FIWARE_IDM_PUBLIC_URL', constants)
 
     @patch('wirecloud.fiware.plugins.IDM_SUPPORT_ENABLED', new=False)
     def test_plugin_idm_disabled(self):
@@ -323,6 +324,7 @@ class TestSocialAuthBackend(WirecloudTestCase, TestCase):
         self.assertIn('FIWARE_PORTALS', constants)
         self.assertNotIn('FIWARE_OFFICIAL_PORTAL', constants)
         self.assertNotIn('FIWARE_IDM_SERVER', constants)
+        self.assertNotIn('FIWARE_IDM_PUBLIC_URL', constants)
 
     def test_organizations_are_created(self):
         backend = Mock()


### PR DESCRIPTION
Related #392 - This PR offers an alternative `AUTHENTICATION_URL` which means it can be different to the `ACCESS_TOKEN_URL`

The fallback is to use `FIWARE_IDM_SERVER` as previously