### PR TITLE
Add widget builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /site/
+/marketplace/widgets/*.wgt
+/marketplace/texts
+/marketplace/temp
+

--- a/marketplace/README.md
+++ b/marketplace/README.md
@@ -1,0 +1,25 @@
+## Widget Builder and  Listing Generator
+
+Usage:
+
+To create the Docker image:
+
+```console
+./widget-builder.sh build
+```
+
+```console
+./widget-builder.sh fiware
+```
+
+```console
+./widget-builder.sh fiware
+```
+
+```console
+./widget-builder.sh fiware
+```
+
+```console
+./marketplace-listing.sh > widgets.md
+```

--- a/marketplace/builder/Dockerfile
+++ b/marketplace/builder/Dockerfile
@@ -1,0 +1,22 @@
+ARG NODE_VERSION=8.15.0-slim
+FROM node:${NODE_VERSION}
+
+ENV DOWNLOAD="latest" \
+    SOURCE_BRANCH="develop" \
+    GITHUB_ACCOUNT="wirecloud-fiware" \
+    GITHUB_REPOSITORY="ngsi-source-operator" 
+
+COPY build.sh /opt/widget-builder/build.sh
+
+RUN apt-get update && \
+	apt-get install -y git unzip python2.7 make build-essential g++ && \
+	ln -s /usr/bin/python2.7 /usr/bin/python  && \
+	npm install -g bower --silent && \
+	npm install -g grunt-cli --silent && \
+	apt-get clean && \
+	chmod +x /opt/widget-builder/build.sh
+
+VOLUME /opt/widget-builder/output
+WORKDIR /opt/widget-builder
+
+CMD ["/opt/widget-builder/build.sh"]

--- a/marketplace/builder/build.sh
+++ b/marketplace/builder/build.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+
+buildWidget () {
+	if [ -e package.json ]
+	then
+		npm install --silent ;
+		(npm install grunt@0.4.5  --save-dev --silent  && grunt build) || (npm install grunt --save-dev --silent && node_modules/grunt/bin/grunt build);
+		if [ -d dist ]; then
+			cp -r dist/* /opt/widget-builder/output;
+		elif [ -d build ]; then
+			cp -r build/* /opt/widget-builder/output;
+		else
+	   		echo "Unknown build dir"
+		fi
+	if
+}
+
+
+if [ "${DOWNLOAD}" = "latest" ] ;
+then
+	RELEASE="${SOURCE_BRANCH}";
+	echo "INFO: Building Latest Development from ${SOURCE_BRANCH} branch.";
+elif [ "${DOWNLOAD}" = "stable" ];
+then
+	RELEASE=$(curl -s https://api.github.com/repos/"${GITHUB_ACCOUNT}"/"${GITHUB_REPOSITORY}"/releases/latest | grep 'tag_name' | cut -d\" -f4);
+	echo "INFO: Building Latest Stable Release: ${RELEASE}";
+else
+ 	RELEASE="${DOWNLOAD}";
+ 	echo "INFO: Building Release: ${RELEASE}";
+fi;
+RELEASE_CONCAT=$(echo "${RELEASE}" | tr / -);
+
+
+wget --no-check-certificate -O source.zip https://github.com/"${GITHUB_ACCOUNT}"/"${GITHUB_REPOSITORY}"/archive/"${RELEASE}".zip;
+unzip -qq source.zip;
+rm source.zip;
+cd "${GITHUB_REPOSITORY}-${RELEASE_CONCAT}";
+
+if [ -e package.json ]
+then
+	buildWidget
+else
+	for D in *; do
+		if [ -d "${D}" ]; then
+			echo
+			echo "${D}"
+			echo
+			cd "${D}"
+			buildWidget
+			cd ..
+		fi
+	done
+fi
+
+ 

--- a/marketplace/builder/marketplace.xsl
+++ b/marketplace/builder/marketplace.xsl
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output omit-xml-declaration="yes" indent="no"  method="text"/>
+
+<xsl:param name="WIDGET" select="'widget'"/>
+
+<xsl:template match="/*">
+<xsl:text>
+</xsl:text>
+<xsl:text>### </xsl:text>
+<xsl:value-of select="details/title"/>
+<xsl:text>
+
+</xsl:text>
+<xsl:value-of select="details/description"/>
+
+* Vendor: <xsl:value-of select="@vendor"/> 
+* Version: <xsl:value-of select="@version"/> 
+* License: <xsl:value-of select="details/license"/> 
+
+<xsl:if test="details/homepage != ''" >
+
+Homepage: [<xsl:value-of select="details/homepage"/>](<xsl:value-of select="details/homepage"/>)
+</xsl:if>
+
+**[Download <xsl:call-template name="replace">
+        <xsl:with-param name="text" select="substring-after($WIDGET, 'widgets/')"/>
+        <xsl:with-param name="search" select="'_'"/>
+        <xsl:with-param name="replace" select="'\_'"/>
+    </xsl:call-template>](<xsl:value-of select="$WIDGET"/>)**
+<xsl:text>
+</xsl:text>
+</xsl:template>
+
+
+<xsl:template name="replace">
+    <xsl:param name="text"/>
+    <xsl:param name="search"/>
+    <xsl:param name="replace"/>
+    <xsl:choose>
+        <xsl:when test="contains($text, $search)">
+            <xsl:variable name="replace-next">
+                <xsl:call-template name="replace">
+                    <xsl:with-param name="text" select="substring-after($text, $search)"/>
+                    <xsl:with-param name="search" select="$search"/>
+                    <xsl:with-param name="replace" select="$replace"/>
+                </xsl:call-template>
+            </xsl:variable>
+            <xsl:value-of 
+                select="
+                    concat(
+                        substring-before($text, $search)
+                    ,   $replace
+                    ,   $replace-next
+                    )
+                "
+            />
+        </xsl:when>
+        <xsl:otherwise><xsl:value-of select="$text"/></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>
+

--- a/marketplace/builder/marketplace.xsl
+++ b/marketplace/builder/marketplace.xsl
@@ -22,13 +22,16 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 <xsl:if test="details/homepage != ''" >
 
 Homepage: [<xsl:value-of select="details/homepage"/>](<xsl:value-of select="details/homepage"/>)
-</xsl:if>
+
 
 **[Download <xsl:call-template name="replace">
         <xsl:with-param name="text" select="substring-after($WIDGET, 'widgets/')"/>
         <xsl:with-param name="search" select="'_'"/>
         <xsl:with-param name="replace" select="'\_'"/>
-    </xsl:call-template>](<xsl:value-of select="$WIDGET"/>)**
+    </xsl:call-template>](<xsl:value-of select="details/homepage"/>/releases/download/<xsl:value-of select="@version"/>/<xsl:value-of select="$WIDGET"/>)**
+</xsl:if>
+
+
 <xsl:text>
 </xsl:text>
 </xsl:template>

--- a/marketplace/builder/marketplace.xsl
+++ b/marketplace/builder/marketplace.xsl
@@ -4,6 +4,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 <xsl:output omit-xml-declaration="yes" indent="no"  method="text"/>
 
 <xsl:param name="WIDGET" select="'widget'"/>
+<xsl:param name="AGILE_DASHBOARDS_VERSION" select="'v0.3'"/>
 
 <xsl:template match="/*">
 <xsl:text>
@@ -21,14 +22,28 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:if test="details/homepage != ''" >
 
-Homepage: [<xsl:value-of select="details/homepage"/>](<xsl:value-of select="details/homepage"/>)
-
-
-**[Download <xsl:call-template name="replace">
+    <xsl:text>Homepage: [</xsl:text>
+    <xsl:value-of select="details/homepage"/>
+    <xsl:text>](</xsl:text>
+    <xsl:value-of select="details/homepage"/>)
+    <xsl:text>**[Download </xsl:text>
+    <xsl:call-template name="replace">
         <xsl:with-param name="text" select="substring-after($WIDGET, 'widgets/')"/>
         <xsl:with-param name="search" select="'_'"/>
         <xsl:with-param name="replace" select="'\_'"/>
-    </xsl:call-template>](<xsl:value-of select="details/homepage"/>/releases/download/<xsl:value-of select="@version"/>/<xsl:value-of select="substring-after($WIDGET, 'widgets/')"/>)**
+    </xsl:call-template>](<xsl:value-of select="details/homepage"/>
+    <xsl:text>/releases/download/</xsl:text>
+    <xsl:choose>
+        <xsl:when test="contains(details/homepage, 'agile-dashboards')">
+            <xsl:value-of select="$AGILE_DASHBOARDS_VERSION"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="@version"/>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>/</xsl:text>
+    <xsl:value-of select="substring-after($WIDGET, 'widgets/')"/>
+    <xsl:text>)**</xsl:text>
 </xsl:if>
 
 

--- a/marketplace/builder/marketplace.xsl
+++ b/marketplace/builder/marketplace.xsl
@@ -21,12 +21,15 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 * License: <xsl:value-of select="details/license"/> 
 
 <xsl:if test="details/homepage != ''" >
+<xsl:text>
 
-    <xsl:text>Homepage: [</xsl:text>
+Homepage: [</xsl:text>
     <xsl:value-of select="details/homepage"/>
-    <xsl:text>](</xsl:text>
-    <xsl:value-of select="details/homepage"/>)
-    <xsl:text>**[Download </xsl:text>
+    <xsl:text>](</xsl:text><xsl:value-of select="details/homepage"/>
+    <xsl:text>)</xsl:text>
+<xsl:text>
+
+**[Download </xsl:text>
     <xsl:call-template name="replace">
         <xsl:with-param name="text" select="substring-after($WIDGET, 'widgets/')"/>
         <xsl:with-param name="search" select="'_'"/>

--- a/marketplace/builder/marketplace.xsl
+++ b/marketplace/builder/marketplace.xsl
@@ -28,7 +28,7 @@ Homepage: [<xsl:value-of select="details/homepage"/>](<xsl:value-of select="deta
         <xsl:with-param name="text" select="substring-after($WIDGET, 'widgets/')"/>
         <xsl:with-param name="search" select="'_'"/>
         <xsl:with-param name="replace" select="'\_'"/>
-    </xsl:call-template>](<xsl:value-of select="details/homepage"/>/releases/download/<xsl:value-of select="@version"/>/<xsl:value-of select="$WIDGET"/>)**
+    </xsl:call-template>](<xsl:value-of select="details/homepage"/>/releases/download/<xsl:value-of select="@version"/>/<xsl:value-of select="substring-after($WIDGET, 'widgets/')"/>)**
 </xsl:if>
 
 

--- a/marketplace/marketplace-listing.sh
+++ b/marketplace/marketplace-listing.sh
@@ -13,9 +13,13 @@ mkdir -p temp
 for D in widgets/*.wgt; do
 	if [ -f "${D}" ]; then
 
+		#echo "${D}"
+
 		unzip -qq -o -j "${D}" "config.xml" -d "temp" 
+
+
 		sed 's/xmlns=/xxxx=/g' temp/config.xml > temp/config2.xml
-		xsltproc --stringparam WIDGET "${D}" widget-builder/marketplace.xsl temp/config2.xml
+		xsltproc --stringparam WIDGET "${D}" builder/marketplace.xsl temp/config2.xml
 
 	fi
 done

--- a/marketplace/marketplace-listing.sh
+++ b/marketplace/marketplace-listing.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+#  Command Line Interface to start all services associated with the Wirecloud Tutorial
+#
+#  For this tutorial the commands are merely a convenience script to run docker
+#
+
+set -e
+
+mkdir -p texts
+mkdir -p temp
+
+for D in widgets/*.wgt; do
+	if [ -f "${D}" ]; then
+
+		unzip -qq -o -j "${D}" "config.xml" -d "temp" 
+		sed 's/xmlns=/xxxx=/g' temp/config.xml > temp/config2.xml
+		xsltproc --stringparam WIDGET "${D}" widget-builder/marketplace.xsl temp/config2.xml
+
+	fi
+done
+
+# rm -rf temp

--- a/marketplace/widget-builder.sh
+++ b/marketplace/widget-builder.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+#
+#  Command Line Interface to start all services associated with the Wirecloud Tutorial
+#
+#  For this tutorial the commands are merely a convenience script to run docker
+#
+
+set -e
+
+
+buildWidget () {
+	echo ""
+	echo "Building" $2 "-" $3
+	echo ""
+	docker run --rm -v "$(pwd)"/widgets:/opt/widget-builder/output -e GITHUB_ACCOUNT=$1 -e GITHUB_REPOSITORY=$2 widget-builder
+}
+
+agileDashboardWidgets(){
+	# Wirecloud Widgets
+	buildWidget Wirecloud agile-dashboards \
+	"Agile Dashboard Components for WireCloud"
+}
+
+wirecloudWidgets(){
+	
+	
+	buildWidget Wirecloud bae-details-widget \
+	"Business API Ecosystem details widget for WireCloud" 
+	buildWidget Wirecloud echarts-widget \
+	"WireCloud widget for ECharts graphs"
+	buildWidget Wirecloud googlecharts-widget \
+	"Generic Graph widget for WireCloud using Google Charts"
+	buildWidget Wirecloud highcharts-widget \
+	"Generic Graph widget for WireCloud using HighCharts"
+
+	buildWidget Wirecloud json-editor-widget \
+	"JSON editor widget for WireCloud"
+	buildWidget Wirecloud map-viewer-widget \
+	"Basic map viewer widget for WireCloud using the Google Maps API"
+	buildWidget Wirecloud markdown-editor-widget \
+	"Markdown editor widget for WireCloud"
+	buildWidget Wirecloud markdown-viewer-widget \
+	"Markdown viewer widget for WireCloud"
+	buildWidget Wirecloud ol3-map-widget \
+	"Map Viewer for WireCloud made using OpenLayers 3"
+	buildWidget Wirecloud panel-widget \
+	"WireCloud widget for displaying simple text messages, like sensor measures"
+	buildWidget Wirecloud spy-wiring-widget \
+	"WireCloud widget for capturing, editing and replaying wiring events"
+	buildWidget Wirecloud value-list-filter-operator \
+	"WireCloud operator to transform lists of objects into lists of values"
+	buildWidget Wirecloud value-filter-operator \
+	"Operator that filters a JSON input and outputs part of its data, as addressed in an object-oriented syntax property"
+	buildWidget Wirecloud workspace-browser-widget \
+	""
+	buildWidget wirecloud-fiware ckan2poi-operator \
+	"A WireCloud operator to process data from CKAN source and convert it to Point of Interest"
+	buildWidget wirecloud-fiware ckan-source-operator \
+	"A WireCloud operator to retrieve data from CKAN datasets"
+	buildWidget wirecloud-fiware context-broker-admin-mashup \
+	"FIWARE Context Broker Administration panel for WireCloud"
+}
+
+fiwareWidgets(){
+	# Wirecloud FIWARE Widgets
+	buildWidget wirecloud-fiware ngsi-source-operator \
+	"WireCloud operator for using Orion Context Broker as data source"
+	buildWidget wirecloud-fiware ngsi-browser-widget \
+	"WireCloud widget for browsing the entities of a orion context broker"
+	buildWidget wirecloud-fiware ngsi-datamodel2poi-operator \
+	"WireCloud operator for displaying data in a map using the FIWARE data models"
+	buildWidget wirecloud-fiware ngsi-entity2poi-operator \
+	"Generic WireCloud operator for converting entities to Points of Interest"
+	buildWidget wirecloud-fiware ngsi-target-operator \
+	"WireCloud operator for using Orion Context Broker as data target"
+	buildWidget wirecloud-fiware ngsi-type-browser-widget \
+	"WireCloud widget for browsing currently in use entities types inside an orion context broker"
+	buildWidget wirecloud-fiware ngsi-subscription-browser-widget \
+	"WireCloud widget for browsing the available subscriptions inside an orion context broker"
+}
+
+
+
+if (( $# != 1 )); then
+    echo "Illegal number of parameters";
+    echo "usage: services [docker|build]";
+    exit 1;
+fi
+
+command="$1"
+case "${command}" in
+	"docker")
+        docker build -t widget-builder ./builder
+        ;;
+    "agileDashboard")
+		# Wirecloud Widgets
+		agileDashboardWidgets;
+		;;
+	"wirecloud")
+		# Wirecloud Widgets
+		wirecloudWidgets;
+		;;
+	"fiware")
+		# Wirecloud-FIWARE Widgets
+		fiwareWidgets;
+		;;
+	"build")
+		echo ""
+		echo "Building" $3 "-" $4
+		echo ""
+		docker run --rm -v "$(pwd)"/widgets:/opt/widget-builder/output -e GITHUB_ACCOUNT=$2 -e GITHUB_REPOSITORY=$3 widget-builder
+		;;
+	*)
+		echo "Command not Found."
+		echo "usage: services [docker|build]"
+		exit 127;
+		;;
+esac
+
+
+

--- a/marketplace/widget-builder.sh
+++ b/marketplace/widget-builder.sh
@@ -21,7 +21,7 @@ pullWidget () {
 	echo ""
 	# OUTPUT=`curl --silent "https://api.github.com/repos/${1}/${2}/releases/latest?client_id=xxxx&client_secret=yyyy" | grep browser_download_url`
 
-	OUTPUT=`curl --silent "https://api.github.com/repos/${1}/${2}/releases/latest?client_id=31a71f8f9737b0159c94&client_secret=c46f82485eb188683c2288e556f6bd93e8bbd655" | grep browser_download_url`
+	OUTPUT=`curl --silent "https://api.github.com/repos/${1}/${2}/releases/latest" | grep browser_download_url`
 
 	X="${OUTPUT:31: $((${#OUTPUT} - 31 - 1))}"
 

--- a/marketplace/widget-builder.sh
+++ b/marketplace/widget-builder.sh
@@ -5,14 +5,30 @@
 #  For this tutorial the commands are merely a convenience script to run docker
 #
 
-set -e
+#set -e
 
 
 buildWidget () {
 	echo ""
 	echo "Building" $2 "-" $3
 	echo ""
-	docker run --rm -v "$(pwd)"/widgets:/opt/widget-builder/output -e GITHUB_ACCOUNT=$1 -e GITHUB_REPOSITORY=$2 widget-builder
+	# docker run --rm -v "$(pwd)"/widgets:/opt/widget-builder/output -e GITHUB_ACCOUNT=$1 -e GITHUB_REPOSITORY=$2 widget-builder
+}
+
+pullWidget () {
+	echo ""
+	echo "Pulling" $2 "-" $3
+	echo ""
+	# OUTPUT=`curl --silent "https://api.github.com/repos/${1}/${2}/releases/latest?client_id=xxxx&client_secret=yyyy" | grep browser_download_url`
+
+	OUTPUT=`curl --silent "https://api.github.com/repos/${1}/${2}/releases/latest?client_id=31a71f8f9737b0159c94&client_secret=c46f82485eb188683c2288e556f6bd93e8bbd655" | grep browser_download_url`
+
+	X="${OUTPUT:31: $((${#OUTPUT} - 31 - 1))}"
+
+	echo $X
+
+	curl -LO $X
+	mv *.wgt widgets
 }
 
 agileDashboardWidgets(){
@@ -24,58 +40,58 @@ agileDashboardWidgets(){
 wirecloudWidgets(){
 	
 	
-	buildWidget Wirecloud bae-details-widget \
+	pullWidget Wirecloud bae-details-widget \
 	"Business API Ecosystem details widget for WireCloud" 
-	buildWidget Wirecloud echarts-widget \
+	pullWidget Wirecloud echarts-widget \
 	"WireCloud widget for ECharts graphs"
-	buildWidget Wirecloud googlecharts-widget \
+	pullWidget Wirecloud googlecharts-widget \
 	"Generic Graph widget for WireCloud using Google Charts"
-	buildWidget Wirecloud highcharts-widget \
+	pullWidget Wirecloud highcharts-widget \
 	"Generic Graph widget for WireCloud using HighCharts"
 
-	buildWidget Wirecloud json-editor-widget \
+	pullWidget Wirecloud json-editor-widget \
 	"JSON editor widget for WireCloud"
-	buildWidget Wirecloud map-viewer-widget \
+	pullWidget Wirecloud map-viewer-widget \
 	"Basic map viewer widget for WireCloud using the Google Maps API"
-	buildWidget Wirecloud markdown-editor-widget \
+	pullWidget Wirecloud markdown-editor-widget \
 	"Markdown editor widget for WireCloud"
-	buildWidget Wirecloud markdown-viewer-widget \
+	pullWidget Wirecloud markdown-viewer-widget \
 	"Markdown viewer widget for WireCloud"
-	buildWidget Wirecloud ol3-map-widget \
+	pullWidget Wirecloud ol3-map-widget \
 	"Map Viewer for WireCloud made using OpenLayers 3"
-	buildWidget Wirecloud panel-widget \
+	pullWidget Wirecloud panel-widget \
 	"WireCloud widget for displaying simple text messages, like sensor measures"
-	buildWidget Wirecloud spy-wiring-widget \
+	pullWidget Wirecloud spy-wiring-widget \
 	"WireCloud widget for capturing, editing and replaying wiring events"
-	buildWidget Wirecloud value-list-filter-operator \
+	pullWidget Wirecloud value-list-filter-operator \
 	"WireCloud operator to transform lists of objects into lists of values"
-	buildWidget Wirecloud value-filter-operator \
+	pullWidget Wirecloud value-filter-operator \
 	"Operator that filters a JSON input and outputs part of its data, as addressed in an object-oriented syntax property"
-	buildWidget Wirecloud workspace-browser-widget \
+	pullWidget Wirecloud workspace-browser-widget \
 	""
-	buildWidget wirecloud-fiware ckan2poi-operator \
+	pullWidget wirecloud-fiware ckan2poi-operator \
 	"A WireCloud operator to process data from CKAN source and convert it to Point of Interest"
-	buildWidget wirecloud-fiware ckan-source-operator \
+	pullWidget wirecloud-fiware ckan-source-operator \
 	"A WireCloud operator to retrieve data from CKAN datasets"
-	buildWidget wirecloud-fiware context-broker-admin-mashup \
+	pullWidget wirecloud-fiware context-broker-admin-mashup \
 	"FIWARE Context Broker Administration panel for WireCloud"
 }
 
 fiwareWidgets(){
 	# Wirecloud FIWARE Widgets
-	buildWidget wirecloud-fiware ngsi-source-operator \
+	pullWidget wirecloud-fiware ngsi-source-operator \
 	"WireCloud operator for using Orion Context Broker as data source"
-	buildWidget wirecloud-fiware ngsi-browser-widget \
+	pullWidget wirecloud-fiware ngsi-browser-widget \
 	"WireCloud widget for browsing the entities of a orion context broker"
-	buildWidget wirecloud-fiware ngsi-datamodel2poi-operator \
+	pullWidget wirecloud-fiware ngsi-datamodel2poi-operator \
 	"WireCloud operator for displaying data in a map using the FIWARE data models"
-	buildWidget wirecloud-fiware ngsi-entity2poi-operator \
+	pullWidget wirecloud-fiware ngsi-entity2poi-operator \
 	"Generic WireCloud operator for converting entities to Points of Interest"
-	buildWidget wirecloud-fiware ngsi-target-operator \
+	pullWidget wirecloud-fiware ngsi-target-operator \
 	"WireCloud operator for using Orion Context Broker as data target"
-	buildWidget wirecloud-fiware ngsi-type-browser-widget \
+	pullWidget wirecloud-fiware ngsi-type-browser-widget \
 	"WireCloud widget for browsing currently in use entities types inside an orion context broker"
-	buildWidget wirecloud-fiware ngsi-subscription-browser-widget \
+	pullWidget wirecloud-fiware ngsi-subscription-browser-widget \
 	"WireCloud widget for browsing the available subscriptions inside an orion context broker"
 }
 


### PR DESCRIPTION
Related to #398 

A series of scripts to download code from GitHub and compile the widget. There are issues with the version of libxml used by most widgets which means that it needs to re-compile sources when running npm install, otherwise the Docker script is just a vanilla NodeJS with a few extras.

The listing script assume a linux system with `xsltproc` and `sed` to list details of all Widgets.

