### PR TITLE
Fix social_auth_backend constructor

### DIFF
--- a/src/wirecloud/fiware/social_auth_backend.py
+++ b/src/wirecloud/fiware/social_auth_backend.py
@@ -33,7 +33,6 @@ field, check OAuthBackend class for details on how to extend it.
 """
 
 import base64
-import time
 from urllib.parse import urljoin
 
 from django.conf import settings
@@ -86,7 +85,7 @@ class FIWAREOAuth2(BaseOAuth2):
         ('expires_in', 'expires'),
     ]
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         internal_url = getattr(settings, 'FIWARE_IDM_SERVER', FIWARE_LAB_IDM_SERVER)
         public_url = getattr(settings, 'FIWARE_IDM_PUBLIC_URL', internal_url)
         if public_url is None or str(public_url).strip() == "":
@@ -94,7 +93,7 @@ class FIWAREOAuth2(BaseOAuth2):
 
         self.FIWARE_IDM_SERVER = public_url
         self.AUTHORIZATION_URL = urljoin(public_url, FIWARE_AUTHORIZATION_ENDPOINT)
-        super(FIWAREOAuth2, self).__init__()
+        super(FIWAREOAuth2, self).__init__(*args, **kwargs)
 
     def auth_headers(self):
         token = base64.urlsafe_b64encode(('{0}:{1}'.format(*self.get_key_and_secret()).encode())).decode()

--- a/src/wirecloud/fiware/tests/social_backend.py
+++ b/src/wirecloud/fiware/tests/social_backend.py
@@ -95,9 +95,9 @@ class TestSocialAuthBackend(WirecloudTestCase, TestCase):
         "organizations": [{
             "id": "04ac28b2-54c7-46a7-a606-c62fdc4f1513",
             "name": "Mi organization",
-            "description":"dafsdf",
+            "description": "dafsdf",
             "website": None,
-            "roles":[{"id": "4a923351-b767-4fef-bc92-4a4fa996e88e", "name":"one_role"}]
+            "roles": [{"id": "4a923351-b767-4fef-bc92-4a4fa996e88e", "name": "one_role"}]
         }]
     }
 
@@ -194,11 +194,7 @@ class TestSocialAuthBackend(WirecloudTestCase, TestCase):
         self.assertIn('Basic ', headers['Authorization'])
         self.assertEqual(headers['Authorization'], 'Basic Y2xpZW50OnNlY3JldA==')
 
-    @patch("wirecloud.fiware.social_auth_backend.time.time")
-    def test_extra_data(self, time_mock):
-
-        time_mock.return_value = 10000
-
+    def test_extra_data(self):
         data = self.instance.extra_data("user", "uid", "response")
 
         self.assertEqual(data, {
@@ -246,11 +242,7 @@ class TestSocialAuthBackend(WirecloudTestCase, TestCase):
 
         self.assertEqual(data, self.NEW_USER_DATA_ADMIN)
 
-    @patch("wirecloud.fiware.social_auth_backend.time.time")
-    def test_refresh_token_normalizes_token_expiration_time(self, time_mock):
-
-        time_mock.return_value = 10000
-
+    def test_refresh_token(self):
         data = self.instance.refresh_token("old_access_token")
 
         self.assertEqual(data, {


### PR DESCRIPTION
This PR fixes the following error when configuring WireCloud to use an IdM server:

```
Internal Server Error: /login/fiware/
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.6/site-packages/django/views/decorators/cache.py", line 57, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/social_django/utils.py", line 46, in wrapper
    backend, uri)
  File "/usr/local/lib/python3.6/site-packages/social_django/utils.py", line 28, in load_backend
    return Backend(strategy, redirect_uri)
TypeError: __init__() takes 1 positional argument but 3 were given
```