### PR TITLE
Remove @python_2_unicode_compatible as we are not python2 compatible anymore

### DIFF
--- a/src/wirecloud/catalogue/models.py
+++ b/src/wirecloud/catalogue/models.py
@@ -24,7 +24,6 @@ from urllib.parse import urlparse
 from django.contrib.auth.models import User, Group
 from django.core.cache import cache
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from wirecloud.commons.fields import JSONField
@@ -32,7 +31,6 @@ from wirecloud.commons.utils.http import get_absolute_reverse_url
 from wirecloud.commons.utils.template.parsers import TemplateParser
 
 
-@python_2_unicode_compatible
 class CatalogueResource(models.Model):
 
     RESOURCE_TYPES = ('widget', 'mashup', 'operator')

--- a/src/wirecloud/commons/exceptions.py
+++ b/src/wirecloud/commons/exceptions.py
@@ -17,10 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Wirecloud.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.utils.encoding import python_2_unicode_compatible
 
-
-@python_2_unicode_compatible
 class HttpBadCredentials(Exception):
 
     def __init__(self, message, error_info=None):

--- a/src/wirecloud/commons/haystack_queryparser.py
+++ b/src/wirecloud/commons/haystack_queryparser.py
@@ -23,7 +23,6 @@ import operator
 
 from haystack.query import SQ
 from django.conf import settings
-from django.utils.encoding import python_2_unicode_compatible
 
 
 PATTERN_FIELD_QUERY = re.compile(r"^(\w+):", re.U)
@@ -42,7 +41,6 @@ OP = {
 }
 
 
-@python_2_unicode_compatible
 class NoMatchingBracketsFound(Exception):
 
     def __init__(self, value=''):

--- a/src/wirecloud/commons/models.py
+++ b/src/wirecloud/commons/models.py
@@ -21,7 +21,6 @@ from uuid import uuid4
 
 from django.contrib.auth.models import User, Group
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from markdown.extensions.toc import slugify
 
@@ -55,7 +54,6 @@ class OrganizationManager(models.Manager):
         return org
 
 
-@python_2_unicode_compatible
 class Organization(models.Model):
 
     user = models.OneToOneField(User)
@@ -79,7 +77,6 @@ class TeamManager(models.Manager):
         return self.get(organization=organization, name=name)
 
 
-@python_2_unicode_compatible
 class Team(models.Model):
     """
     Teams are a generic way of categorizing users to apply permissions, or

--- a/src/wirecloud/commons/utils/template/base.py
+++ b/src/wirecloud/commons/utils/template/base.py
@@ -19,8 +19,6 @@
 
 import regex
 
-from django.utils.encoding import python_2_unicode_compatible
-
 
 __all__ = ('is_valid_name', 'is_valid_vendor', 'is_valid_version')
 
@@ -32,7 +30,6 @@ VERSION_RE = regex.compile(r'^(?:[1-9]\d*\.|0\.)*(?:[1-9]\d*|0)(?:(?:a|b|rc)[1-9
 CONTACT_RE = regex.compile(r'([^<(\s]+(?:\s+[^<()\s]+)*)(?:\s*<([^>]*)>)?(?:\s*\(([^)]*)\))?')
 
 
-@python_2_unicode_compatible
 class TemplateParseException(Exception):
 
     def __init__(self, msg):
@@ -52,7 +49,6 @@ class ObsoleteFormatError(TemplateFormatError):
         super(ObsoleteFormatError, self).__init__('Component description uses a no longer supported format')
 
 
-@python_2_unicode_compatible
 class UnsupportedFeature(Exception):
 
     def __init__(self, msg):

--- a/src/wirecloud/commons/utils/wgt.py
+++ b/src/wirecloud/commons/utils/wgt.py
@@ -24,12 +24,9 @@ from shutil import rmtree
 from urllib.request import pathname2url
 import zipfile
 
-from django.utils.encoding import python_2_unicode_compatible
-
 from wirecloud.commons.utils.template import TemplateParser
 
 
-@python_2_unicode_compatible
 class InvalidContents(Exception):
 
     def __init__(self, message, details=None):
@@ -82,7 +79,7 @@ class WgtFile(object):
     def extract_localized_files(self, file_name, output_dir):
 
         (file_root, ext) = os.path.splitext(file_name)
-        search_re = re.compile(re.escape(file_root) + '(?:.\w\w(?:-\w\w)?)?' + re.escape(ext))
+        search_re = re.compile(re.escape(file_root) + r'(?:.\w\w(?:-\w\w)?)?' + re.escape(ext))
         for name in self._zip.namelist():
             if search_re.match(name):
                 self.extract_file(name, os.path.join(output_dir, os.path.basename(name)))

--- a/src/wirecloud/oauth2provider/models.py
+++ b/src/wirecloud/oauth2provider/models.py
@@ -21,11 +21,9 @@ from django.contrib.auth.models import User
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext as _
 
 
-@python_2_unicode_compatible
 class Application(models.Model):
 
     client_id = models.CharField(_('Client ID'), max_length=40, blank=False, primary_key=True)
@@ -38,7 +36,6 @@ class Application(models.Model):
         return self.client_id
 
 
-@python_2_unicode_compatible
 class Code(models.Model):
 
     client = models.ForeignKey(Application, on_delete=models.CASCADE)
@@ -55,7 +52,6 @@ class Code(models.Model):
         return self.code
 
 
-@python_2_unicode_compatible
 class Token(models.Model):
 
     token = models.CharField(_('Token'), max_length=40, blank=False, primary_key=True)

--- a/src/wirecloud/platform/context/models.py
+++ b/src/wirecloud/platform/context/models.py
@@ -18,11 +18,9 @@
 # along with Wirecloud.  If not, see <http://www.gnu.org/licenses/>.
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import gettext_lazy as _
 
 
-@python_2_unicode_compatible
 class Constant(models.Model):
 
     concept = models.CharField(_('Concept'), max_length=255, unique=True, null=False, blank=False)

--- a/src/wirecloud/platform/iwidget/models.py
+++ b/src/wirecloud/platform/iwidget/models.py
@@ -18,14 +18,12 @@
 # along with Wirecloud.  If not, see <http://www.gnu.org/licenses/>.
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext as _
 
 from wirecloud.commons.fields import JSONField
 from wirecloud.platform.wiring.utils import remove_widget_from_wiring_status
 
 
-@python_2_unicode_compatible
 class IWidget(models.Model):
 
     widget = models.ForeignKey('platform.Widget', on_delete=models.SET_NULL, verbose_name=_('Widget'), null=True)

--- a/src/wirecloud/platform/markets/models.py
+++ b/src/wirecloud/platform/markets/models.py
@@ -19,13 +19,11 @@
 
 from django.contrib.auth.models import User
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext as _
 
 from wirecloud.commons.fields import JSONField
 
 
-@python_2_unicode_compatible
 class Market(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE, verbose_name=_('User'), blank=True)
     name = models.CharField(_('Name'), max_length=50)
@@ -41,7 +39,6 @@ class Market(models.Model):
         return self.user.username + '/' + self.name
 
 
-@python_2_unicode_compatible
 class MarketUserData(models.Model):
 
     market = models.ForeignKey(Market, on_delete=models.CASCADE, verbose_name=_('Market'), blank=False, null=False)

--- a/src/wirecloud/platform/preferences/models.py
+++ b/src/wirecloud/platform/preferences/models.py
@@ -19,13 +19,10 @@
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.contrib.auth.signals import user_logged_in
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import check_for_language, gettext_lazy as _, LANGUAGE_SESSION_KEY
 
 
-@python_2_unicode_compatible
 class PlatformPreference(models.Model):
 
     user = models.ForeignKey(User, on_delete=models.CASCADE)
@@ -40,7 +37,6 @@ class PlatformPreference(models.Model):
         return self.name
 
 
-@python_2_unicode_compatible
 class WorkspacePreference(models.Model):
 
     workspace = models.ForeignKey('platform.Workspace', on_delete=models.CASCADE)
@@ -56,7 +52,6 @@ class WorkspacePreference(models.Model):
         return self.name
 
 
-@python_2_unicode_compatible
 class TabPreference(models.Model):
 
     tab = models.ForeignKey('platform.Tab', on_delete=models.CASCADE)

--- a/src/wirecloud/platform/widget/models.py
+++ b/src/wirecloud/platform/widget/models.py
@@ -21,11 +21,9 @@ import random
 
 from django.core.cache import cache
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext as _
 
 
-@python_2_unicode_compatible
 class XHTML(models.Model):
 
     uri = models.CharField(_('URI'), max_length=255, unique=True)
@@ -66,7 +64,6 @@ class WidgetManager(models.Manager):
         return super(WidgetManager, self).get_query_set().select_related('resource')
 
 
-@python_2_unicode_compatible
 class Widget(models.Model):
 
     resource = models.OneToOneField('catalogue.CatalogueResource')

--- a/src/wirecloud/platform/workspace/mashupTemplateParser.py
+++ b/src/wirecloud/platform/workspace/mashupTemplateParser.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Wirecloud.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext as _
 
 from wirecloud.catalogue.models import CatalogueResource
@@ -66,7 +65,6 @@ def buildWorkspaceFromTemplate(template, user, allow_renaming=False, new_name=No
     return (workspace, user_workspace)
 
 
-@python_2_unicode_compatible
 class MissingDependencies(Exception):
 
     def __init__(self, missing_dependencies):

--- a/src/wirecloud/platform/workspace/models.py
+++ b/src/wirecloud/platform/workspace/models.py
@@ -21,7 +21,6 @@ import time
 
 from django.contrib.auth.models import User, Group
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext as _
 
 from wirecloud.commons.fields import JSONField
@@ -31,7 +30,6 @@ def now_timestamp():
     return time.time() * 1000
 
 
-@python_2_unicode_compatible
 class Workspace(models.Model):
 
     creator = models.ForeignKey(User, on_delete=models.CASCADE, related_name='creator', verbose_name=_('Creator'), blank=False, null=False)
@@ -85,7 +83,6 @@ class Workspace(models.Model):
         return self.public or self.users.count() > 1 or self.groups.count() > 1
 
 
-@python_2_unicode_compatible
 class UserWorkspace(models.Model):
 
     workspace = models.ForeignKey(Workspace, on_delete=models.CASCADE)
@@ -101,7 +98,6 @@ class UserWorkspace(models.Model):
         return "%s - %s" % (self.workspace, self.user)
 
 
-@python_2_unicode_compatible
 class Tab(models.Model):
 
     name = models.CharField(_('Name'), max_length=30)


### PR DESCRIPTION
This PR removes usage of the `@python_2_unicode_compatible`  decorator now that we are not python2 compatible.