### PR TITLE
Update links that point to FIWARE Academy

### DIFF
--- a/docs/development/eclipse_ide.md
+++ b/docs/development/eclipse_ide.md
@@ -105,7 +105,7 @@ Once created the project, you will obtain the following features in addition to 
     ![](../images/user_guide/WireCloudIDE/import_widget2.png) ![](../images/user_guide/WireCloudIDE/import_widget3.png)
 
 -   Follow the _3.1.3. Making requests and wiring_ tutorial available on the
-    [WireCloud's course @ FIWARE Academy](http://edu.fiware.org/course/view.php?id=53#section-3).
+    [WireCloud's course @ FIWARE Academy](https://fiware-academy.readthedocs.io/en/latest/processing/wirecloud/index.html).
 -   Add the widget to the WireCloud server using the Servers view (see the
     [Adding WireCloud servers](#adding-wirecloud-servers) sections for more info). The first step is opening the "Add
     and remove ..." view:

--- a/docs/development/widget_and_operators.md
+++ b/docs/development/widget_and_operators.md
@@ -83,6 +83,6 @@ WireCloud provides the following tools to ease this process:
 # What next?
 
 We recommend you to continue following the
-[WireCloud course at the FIWARE Academy](http://edu.fiware.org/course/view.php?id=53), as we think that it's easier to
+[WireCloud course at the FIWARE Academy](https://fiware-academy.readthedocs.io/en/latest/processing/wirecloud/index.html), as we think that it's easier to
 learn by examples. Anyway, the following sections will provide the reference documentation for developing widgets and
 operators for WireCloud.

--- a/docs/slides/1.1_Introduction.html
+++ b/docs/slides/1.1_Introduction.html
@@ -53,7 +53,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide cover">
                         
 
-                        <header class="slide-header"><h1>Introduction to WireCloud</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>Introduction to WireCloud</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/slides/1.2_Integration with other GEs.html
+++ b/docs/slides/1.2_Integration with other GEs.html
@@ -53,7 +53,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide cover">
                         
 
-                        <header class="slide-header"><h1>Integration with other GEs</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>Integration with other GEs</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/slides/2.3_End-user exercises.html
+++ b/docs/slides/2.3_End-user exercises.html
@@ -53,7 +53,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide cover">
                         
 
-                        <header class="slide-header"><h1>WireCloud End-User Exercises</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>WireCloud End-User Exercises</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/slides/3.1.0_quick_start.html
+++ b/docs/slides/3.1.0_quick_start.html
@@ -53,7 +53,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide cover">
                         
 
-                        <header class="slide-header"><h1>Quick Start Tutorial</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>Quick Start Tutorial</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/slides/3.1.1_Creating widgets and operator descriptions.html
+++ b/docs/slides/3.1.1_Creating widgets and operator descriptions.html
@@ -53,7 +53,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide cover">
                         
 
-                        <header class="slide-header"><h1>Creating widget and operator descriptions</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>Creating widget and operator descriptions</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/slides/3.1.2_Logging error messages.html
+++ b/docs/slides/3.1.2_Logging error messages.html
@@ -53,7 +53,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide cover">
                         
 
-                        <header class="slide-header"><h1>Logging error messages</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>Logging error messages</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/slides/3.1.3_Making requests and wiring.html
+++ b/docs/slides/3.1.3_Making requests and wiring.html
@@ -53,7 +53,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide cover">
                         
 
-                        <header class="slide-header"><h1>Making requests and wiring</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>Making requests and wiring</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/slides/3.1.4_Adding preferences.html
+++ b/docs/slides/3.1.4_Adding preferences.html
@@ -53,7 +53,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide cover">
                         
 
-                        <header class="slide-header"><h1>Adding preferences</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>Adding preferences</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/slides/3.1.5_Accessing context information.html
+++ b/docs/slides/3.1.5_Accessing context information.html
@@ -53,7 +53,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide cover">
                         
 
-                        <header class="slide-header"><h1>Accessing context information</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>Accessing context information</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/slides/3.1.6_Translating widgets.html
+++ b/docs/slides/3.1.6_Translating widgets.html
@@ -53,7 +53,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide cover">
                         
 
-                        <header class="slide-header"><h1>Translating widgets</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>Translating widgets</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/slides/3.1.7_Dynamic_dashboards.html
+++ b/docs/slides/3.1.7_Dynamic_dashboards.html
@@ -53,7 +53,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide cover">
                         
 
-                        <header class="slide-header"><h1>Dynamic dashboards</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>Dynamic dashboards</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/slides/3.1.8_Accessing_third-party_servicies_using_IdM_tokens.html
+++ b/docs/slides/3.1.8_Accessing_third-party_servicies_using_IdM_tokens.html
@@ -53,7 +53,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide cover">
                         
 
-                        <header class="slide-header"><h1>Accessing third-party servicies using IdM tokens</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>Accessing third-party servicies using IdM tokens</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/slides/3.2.1_Using Orion Context Broker.html
+++ b/docs/slides/3.2.1_Using Orion Context Broker.html
@@ -53,7 +53,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide cover">
                         
 
-                        <header class="slide-header"><h1>Using Orion Context Broker</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>Using Orion Context Broker</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/slides/3.2.2_Using Object Storage.html
+++ b/docs/slides/3.2.2_Using Object Storage.html
@@ -53,7 +53,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide cover">
                         
 
-                        <header class="slide-header"><h1>Using Object Storage</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>Using Object Storage</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/slides/3.4_Developer exercises.html
+++ b/docs/slides/3.4_Developer exercises.html
@@ -53,7 +53,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide cover">
                         
 
-                        <header class="slide-header"><h1>WireCloud Developer Exercises</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>WireCloud Developer Exercises</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/slides/4.2_Internationalisation.html
+++ b/docs/slides/4.2_Internationalisation.html
@@ -53,7 +53,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide cover">
                         
 
-                        <header class="slide-header"><h1>Translating WireCloud</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>Translating WireCloud</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/slides/4.4_Administrator exercises.html
+++ b/docs/slides/4.4_Administrator exercises.html
@@ -53,7 +53,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide cover">
                         
 
-                        <header class="slide-header"><h1>WireCloud Administrator Exercises</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>WireCloud Administrator Exercises</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/slides/fiwaretheme/base.html
+++ b/docs/slides/fiwaretheme/base.html
@@ -80,7 +80,7 @@ Nicolas Perriault (nperriault@gmail.com)
                     <section class="slide{% if slide.classes %}{% for class in slide.classes %} {{ class }}{% endfor %}{% endif %}">
                         {% if 'cover' in slide.classes %}
 
-                        <header class="slide-header"><h1>{{ head_title }}</h1><h2>Application Mashup (WireCloud) course @ http://edu.fiware.org</h2></header>
+                        <header class="slide-header"><h1>{{ head_title }}</h1><h2>Application Mashup (WireCloud) course @ https://fiware-academy.readthedocs.io/</h2></header>
                         <img class="fiware-contact" src="fiwaretheme/images/FIWARE-contact.png"/>
                         <img class="fiware-logo" src="fiwaretheme/images/FIWARE-full.png"/>
                         <img class="fiware-lab-ops-logo" src="fiwaretheme/images/FIWARE-lab-ops-full.png"/>

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -566,7 +566,7 @@ You can also obtain the code you have to copy & paste into other web pages follo
 
 ## Additional sources of information
 
-See the [Application Mashup GE fundamentals course](http://edu.fiware.org/course/view.php?id=53) at the FIWARE Academy
+See the [Application Mashup GE fundamentals course](https://fiware-academy.readthedocs.io/en/latest/processing/wirecloud/index.html) at the FIWARE Academy
 for detailed documentation on how to use WireCloud from different perspectives (end-user, developer and administrators).
 Another source of information is [the WireCloud website](https://conwet.fi.upm.es/wirecloud/) where you can find more
 general information and other interesting resources such as demo videos.


### PR DESCRIPTION
Hi @aarranz,

As @jason-fox mentioned that the ‘old’ Academy has been replaced by new URLs, I updated links in the WireCloud documents. It's synched in the Japanese translation in PR #430. Please review this PR.

Thanks.
