### PR TITLE
Upgrade to channels 2.x

### DIFF
--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -951,19 +951,22 @@ The steps for enabling this support are the following:
 <zbr>1.   Install [Django channels](https://channels.readthedocs.io/en/latest/):
 
 ```bash
-pip install channels
+pip install "channels<3"
 ```
 
 <zbr>2.   Add `channels` and `wirecloud.live` into the `INSTALLED_APPS` setting in the `settings.py` file.
 
-<zbr>3.   Configure the channels framework by configuring the `CHANNEL_LAYERS` setting. For example, you can make use of the
-    following configuration:
+<zbr>3.   Configure the channels framework by configuring `ASGI_APPLICATION` and `CHANNEL_LAYERS` settings. For example,
+    you can make use of the following configuration:
 
 ```python
+ASGI_APPLICATION = 'wirecloud.live.routing.application'
 CHANNEL_LAYERS = {
-    "default": {
-        "BACKEND": "asgiref.inmemory.ChannelLayer",
-        "ROUTING": "wirecloud.live.routing.channel_routing",
+    'default': {
+        'BACKEND': 'channels_redis.core.RedisChannelLayer',
+        'CONFIG': {
+            "hosts": [('127.0.0.1', 6379)],
+        },
     },
 }
 ```

--- a/src/ci_scripts/travis.sh
+++ b/src/ci_scripts/travis.sh
@@ -39,7 +39,7 @@ done
 pip install "channels<3" "lxml<4.4" ${TRAVIS_BUILD_DIR}/src/dist/wirecloud*.whl
 
 # Install the required testing tools
-pip install django-nose parameterized radon
+pip install -r ${TRAVIS_BUILD_DIR}/src/requirements-dev.txt
 
 # Configure WireCloud
 cat ${TRAVIS_BUILD_DIR}/src/ci_scripts/base_settings.py > settings.py

--- a/src/ci_scripts/travis.sh
+++ b/src/ci_scripts/travis.sh
@@ -36,7 +36,7 @@ done
 
 # Build and install WireCloud
 ./setup.py bdist_wheel &> /dev/null
-pip install "lxml<4.4" ${TRAVIS_BUILD_DIR}/src/dist/wirecloud*.whl
+pip install "channels<3" "lxml<4.4" ${TRAVIS_BUILD_DIR}/src/dist/wirecloud*.whl
 
 # Install the required testing tools
 pip install django-nose parameterized radon

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -1,2 +1,3 @@
 django-nose
 parameterized
+radon

--- a/src/wirecloud/live/apps.py
+++ b/src/wirecloud/live/apps.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2016 CoNWeT Lab., Universidad Politécnica de Madrid
+# Copyright (c) 2019 Future Internet Consulting and Development Solutions S.L.
 
 # This file is part of Wirecloud.
 
@@ -19,6 +20,8 @@
 
 from django.apps import AppConfig
 
+from wirecloud.live.signals.handlers import install_signals
+
 
 class WirecloudLiveConfig(AppConfig):
 
@@ -26,5 +29,4 @@ class WirecloudLiveConfig(AppConfig):
     verbose_name = "WireCloud Live Extension"
 
     def ready(self):
-        # import signal handlers
-        import wirecloud.live.signals.handlers  # noqa
+        install_signals()

--- a/src/wirecloud/live/routing.py
+++ b/src/wirecloud/live/routing.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2016 CoNWeT Lab., Universidad Politécnica de Madrid
+# Copyright (c) 2019 Future Internet Consulting and Development Solutions S.L.
 
 # This file is part of Wirecloud.
 
@@ -17,10 +17,17 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Wirecloud.  If not, see <http://www.gnu.org/licenses/>.
 
-from channels.routing import route
-from wirecloud.live.consumers import ws_connect, ws_disconnect
 
-channel_routing = [
-    route("websocket.connect", ws_connect, path="^/api/live"),
-    route("websocket.disconnect", ws_disconnect),
-]
+from channels.auth import AuthMiddlewareStack
+from channels.routing import ProtocolTypeRouter, URLRouter
+from django.urls import path
+
+from . import consumers
+
+application = ProtocolTypeRouter({
+    "websocket": AuthMiddlewareStack(
+        URLRouter([
+            path("api/live", consumers.LiveConsumer)
+        ])
+    )
+})

--- a/src/wirecloud/live/tests.py
+++ b/src/wirecloud/live/tests.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2016 CoNWeT Lab., Universidad Politécnica de Madrid
+# Copyright (c) 2019 Future Internet Consulting and Development Solutions S.L.
 
 # This file is part of Wirecloud.
 
@@ -17,51 +18,128 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Wirecloud.  If not, see <http://www.gnu.org/licenses/>.
 
-import datetime
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
-from django.conf import settings
 from django.contrib.auth.models import User, Group
-from django.test import TransactionTestCase
+from django.test import TestCase
+from django.utils import timezone
 
 from wirecloud.catalogue.models import CatalogueResource
 from wirecloud.commons.utils.testcases import WirecloudTestCase
-from wirecloud.platform.models import Workspace
+from wirecloud.platform.models import CatalogueResource, Workspace
+import wirecloud.live
+
+try:  # pragma: no cover
+    import channels  # noqa
+    CHANNELS_INSTALLED = True
+
+    # Those modules cannot be imported if the channels module is not installed
+    from wirecloud.live.apps import WirecloudLiveConfig
+    from wirecloud.live.signals.handlers import install_signals, mac_update, update_users_or_groups, notify, workspace_update
+except ModuleNotFoundError:  # pragma: no cover
+    CHANNELS_INSTALLED = False
 
 
-@unittest.skipIf('wirecloud.live' not in settings.INSTALLED_APPS, 'wirecloud.live not installed')
+@unittest.skipIf(not CHANNELS_INSTALLED, 'django channels package not installed')
 @patch('wirecloud.live.signals.handlers.notify')
-class LiveNotificationsTestCase(WirecloudTestCase, TransactionTestCase):
+class LiveNotificationsTestCase(WirecloudTestCase, TestCase):
 
     fixtures = ('selenium_test_data', 'user_with_workspaces')
     tags = ('wirecloud-noselenium', 'wirecloud-live')
+    populate = False
+    use_search_indexes = False
 
     def setUp(self):
         self.normuser = User.objects.get(username="normuser")
+        self.orggroup = Group.objects.get(name="org")
 
     def test_mac_install_by_user_are_notified(self, notify_mock):
-        instance = CatalogueResource.objects.create(type=1, creation_date=datetime.datetime.now(), short_name="MyWidget", vendor="Wirecloud", version="1.0")
-        instance.users.add(self.normuser)
+        instance = Mock(speck=CatalogueResource)
+
+        update_users_or_groups(
+            sender=CatalogueResource.users.through,
+            instance=instance,
+            action="pre_add",
+            reverse=False,
+            model=User,
+            pk_set={self.normuser.pk},
+            using="default"
+        )
+
         notify_mock.assert_called_once_with(
             {
-                "component": "Wirecloud/MyWidget/1.0",
+                "component": instance.local_uri_part,
                 "action": "install",
                 "category": "component"
             },
             {"normuser"}
         )
 
-    def test_mac_user_clear_are_notified(self, notify_mock):
-        instance = CatalogueResource.objects.create(type=1, creation_date=datetime.datetime.now(), short_name="MyWidget", vendor="Wirecloud", version="1.0")
-        instance.users.add(self.normuser)
-        notify_mock.reset_mock()
+    def test_mac_install_by_group_are_notified(self, notify_mock):
+        instance = CatalogueResource(type=1, creation_date=timezone.now(), short_name="MyWidget", vendor="Wirecloud", version="1.0")
 
-        instance.users.clear()
+        update_users_or_groups(
+            sender=CatalogueResource.groups.through,
+            instance=instance,
+            action="pre_add",
+            reverse=False,
+            model=Group,
+            pk_set={self.orggroup.pk},
+            using="default"
+        )
 
         notify_mock.assert_called_once_with(
             {
                 "component": "Wirecloud/MyWidget/1.0",
+                "action": "install",
+                "category": "component"
+            },
+            {"orguser", "org"}
+        )
+
+    def test_mac_groups_clear_are_notified(self, notify_mock):
+        group = Mock()
+        group.user_set.values_list.return_value = ("normuser",)
+        instance = Mock(spec=CatalogueResource)
+        instance.groups.all.return_value = (group,)
+
+        update_users_or_groups(
+            sender=CatalogueResource.groups.through,
+            instance=instance,
+            action="pre_clear",
+            reverse=False,
+            model=Group,
+            pk_set={self.normuser.pk},
+            using="default"
+        )
+
+        notify_mock.assert_called_once_with(
+            {
+                "component": instance.local_uri_part,
+                "action": "uninstall",
+                "category": "component"
+            },
+            {"normuser"}
+        )
+
+    def test_mac_user_clear_are_notified(self, notify_mock):
+        instance = Mock(spec=CatalogueResource)
+        instance.users.all().values_list.return_value = ("normuser",)
+
+        update_users_or_groups(
+            sender=CatalogueResource.users.through,
+            instance=instance,
+            action="pre_clear",
+            reverse=False,
+            model=User,
+            pk_set={self.normuser.pk},
+            using="default"
+        )
+
+        notify_mock.assert_called_once_with(
+            {
+                "component": instance.local_uri_part,
                 "action": "uninstall",
                 "category": "component"
             },
@@ -69,15 +147,21 @@ class LiveNotificationsTestCase(WirecloudTestCase, TransactionTestCase):
         )
 
     def test_mac_uninstall_by_user_are_notified(self, notify_mock):
-        instance = CatalogueResource.objects.create(type=1, creation_date=datetime.datetime.now(), short_name="MyWidget", vendor="Wirecloud", version="1.0")
-        instance.users.add(self.normuser)
-        notify_mock.reset_mock()
+        instance = Mock(spec=CatalogueResource)
 
-        instance.users.remove(self.normuser)
+        update_users_or_groups(
+            sender=CatalogueResource.users.through,
+            instance=instance,
+            action="pre_remove",
+            reverse=False,
+            model=User,
+            pk_set={self.normuser.pk},
+            using="default"
+        )
 
         notify_mock.assert_called_once_with(
             {
-                "component": "Wirecloud/MyWidget/1.0",
+                "component": instance.local_uri_part,
                 "action": "uninstall",
                 "category": "component"
             },
@@ -85,8 +169,21 @@ class LiveNotificationsTestCase(WirecloudTestCase, TransactionTestCase):
         )
 
     def test_workspace_updates_are_notified(self, notify_mock):
-        instance = Workspace.objects.get(pk="2")
-        instance.save()
+        instance = Mock(spec=Workspace)
+        instance.id = 2
+        instance.public = False
+        instance.users.values_list.return_value = ("user_with_workspaces",)
+        instance.groups.all.return_value = ()
+
+        workspace_update(
+            sender=Workspace,
+            instance=instance,
+            created=False,
+            raw={},
+            using="default",
+            update_fields=()
+        )
+
         notify_mock.assert_called_once_with(
             {
                 "workspace": "2",
@@ -96,14 +193,51 @@ class LiveNotificationsTestCase(WirecloudTestCase, TransactionTestCase):
             {"user_with_workspaces"}
         )
 
-    def test_workspace_simple_updates_are_notified(self, notify_mock):
-        instance = Workspace.objects.get(pk="2")
-        instance.description = "New description"
-        with patch("time.time", return_value=123456):
-            instance.save(update_fields=("description",))
+    def test_workspace_update_support_empty_update_fields(self, notify_mock):
+        instance = Mock(spec=Workspace)
+        instance.id = 2
+        instance.public = False
+        instance.users.values_list.return_value = ()
+        instance.groups.all.return_value = ()
+
+        workspace_update(
+            sender=Workspace,
+            instance=instance,
+            created=False,
+            raw={},
+            using="default",
+            update_fields=None
+        )
+
         notify_mock.assert_called_once_with(
             {
-                "workspace": "2",
+                "workspace": "%s" % instance.id,
+                "action": "update",
+                "category": "workspace",
+            },
+            set()
+        )
+
+    def test_workspace_simple_updates_are_notified(self, notify_mock):
+        instance = Mock(spec=Workspace)
+        instance.public = False
+        instance.description = "New description"
+        instance.last_modified = 123456000
+        instance.users.values_list.return_value = ("user_with_workspaces",)
+        instance.groups.all.return_value = ()
+
+        workspace_update(
+            sender=Workspace,
+            instance=instance,
+            created=False,
+            raw={},
+            using="default",
+            update_fields=('description', 'last_modified')
+        )
+
+        notify_mock.assert_called_once_with(
+            {
+                "workspace": "%s" % instance.id,
                 "action": "update",
                 "category": "workspace",
                 "description": "New description",
@@ -113,12 +247,23 @@ class LiveNotificationsTestCase(WirecloudTestCase, TransactionTestCase):
         )
 
     def test_workspace_simple_updates_are_notified_shared(self, notify_mock):
-        instance = Workspace.objects.get(pk="2")
-        instance.userworkspace_set.create(user=User.objects.get(username="normuser"))
-        instance.groups.add(Group.objects.get(name="org"))
+        instance = Mock(spec=Workspace)
+        instance.id = 2
+        instance.public = False
+        instance.users.values_list.return_value = ("normuser", "user_with_workspaces")
+        instance.groups.all.return_value = (self.orggroup,)
         instance.description = "New description"
-        with patch("time.time", return_value=123456):
-            instance.save(update_fields=("description",))
+        instance.last_modified = 123456000
+
+        workspace_update(
+            sender=Workspace,
+            instance=instance,
+            created=False,
+            raw={},
+            using="default",
+            update_fields=('description', 'last_modified')
+        )
+
         notify_mock.assert_called_once_with(
             {
                 "workspace": "2",
@@ -131,10 +276,21 @@ class LiveNotificationsTestCase(WirecloudTestCase, TransactionTestCase):
         )
 
     def test_workspace_public_updates_are_notified(self, notify_mock):
-        instance = Workspace.objects.get(pk="4")
+        instance = Mock(spec=Workspace)
+        instance.id = 4
+        instance.public = True
         instance.description = "New description"
-        with patch("time.time", return_value=123456):
-            instance.save(update_fields=("description",))
+        instance.last_modified = 123456000
+
+        workspace_update(
+            sender=Workspace,
+            instance=instance,
+            created=False,
+            raw={},
+            using="default",
+            update_fields=('description', 'last_modified')
+        )
+
         notify_mock.assert_called_once_with(
             {
                 "workspace": "4",
@@ -145,3 +301,55 @@ class LiveNotificationsTestCase(WirecloudTestCase, TransactionTestCase):
             },
             {"*"}
         )
+
+    def test_mac_install_should_be_ignored_post(self, notify_mock):
+        instance = Mock(speck=CatalogueResource)
+
+        update_users_or_groups(
+            sender=CatalogueResource.users.through,
+            instance=instance,
+            action="post_add",
+            reverse=False,
+            model=User,
+            pk_set={self.normuser.pk},
+            using="default"
+        )
+
+        notify_mock.assert_not_called()
+
+    def test_mac_update(self, notify_mock):
+        instance = Mock(speck=CatalogueResource)
+        instance.public = True
+
+        mac_update(
+            sender=CatalogueResource.users.through,
+            instance=instance,
+            created=False,
+            raw=None
+        )
+
+        notify_mock.assert_called_once_with(
+            {
+                "component": instance.local_uri_part,
+                "action": "update",
+                "category": "component"
+            },
+            {"*"}
+        )
+
+    @patch("wirecloud.live.signals.handlers.channels")
+    @patch("wirecloud.live.signals.handlers.async_to_sync")
+    def test_notify(self, notify_mock, channels_mock, async_to_sync_mock):
+        notify({}, ("a",))
+
+    @patch("wirecloud.live.signals.handlers.m2m_changed")
+    @patch("wirecloud.live.signals.handlers.post_save")
+    def test_install_signals(self, notify_mock, channels_mock, async_to_sync_mock):
+        install_signals()
+
+    @patch("wirecloud.live.apps.install_signals")
+    def test_live_app_ready(self, notify_mock, install_signals_mock):
+        app = WirecloudLiveConfig("wirecloud.live", wirecloud.live)
+        app.ready()
+
+        install_signals_mock.toHaveBeenCalled()

--- a/src/wirecloud/live/utils.py
+++ b/src/wirecloud/live/utils.py
@@ -21,7 +21,7 @@ from base64 import b64encode
 
 
 def build_group_name(name):
-    return b"wc-%s" % b64encode(name.encode('utf-8'), b'-_').replace(b'=', b'.')
+    return "wc-%s" % b64encode(name.encode('utf-8'), b'-_').replace(b'=', b'').decode('utf-8')
 
 
 WIRECLOUD_BROADCAST_GROUP = build_group_name('live-*')


### PR DESCRIPTION
Now that WireCloud has moved to Django 2, current `wirecloud.live` module has to be migrated into channels 2 (channels 1 is not compatible with Django 2).

This PR migrates current code to channels 2 and makes current unit tests runnable without having it installed and configured.