### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-catalogue/docker-compose.yml
+++ b/docker-catalogue/docker-compose.yml
@@ -20,7 +20,7 @@ services:
         environment:
             - POSTGRES_PASSWORD=wirepass   # Change this password!
         volumes:
-            - ./postgres-data:/var/lib/postgresql/data
+            - /var/lib/postgresql/data
 
 
     elasticsearch:

--- a/docker-catalogue/docker-compose.yml
+++ b/docker-catalogue/docker-compose.yml
@@ -9,7 +9,7 @@ services:
             - 80:80
         volumes:
             - ./nginx.conf:/etc/nginx/nginx.conf:ro
-            - ./wirecloud-static:/var/www/static:ro
+            - wirecloud-static:/var/www/static:ro
         depends_on:
             - wirecloud
 
@@ -20,14 +20,14 @@ services:
         environment:
             - POSTGRES_PASSWORD=wirepass   # Change this password!
         volumes:
-            - /var/lib/postgresql/data
+            - postgres-data:/var/lib/postgresql/data
 
 
     elasticsearch:
         restart: always
         image: elasticsearch:2.4
         volumes:
-            - ./elasticsearch-data:/usr/share/elasticsearch/data
+            - elasticsearch-data:/usr/share/elasticsearch/data
         command: elasticsearch -Des.index.max_result_window=50000
 
 
@@ -58,7 +58,13 @@ services:
             #- SOCIAL_AUTH_FIWARE_KEY=${SOCIAL_AUTH_FIWARE_KEY}
             #- SOCIAL_AUTH_FIWARE_SECRET=${SOCIAL_AUTH_FIWARE_SECRET}
         volumes:
-            - ./wirecloud-data:/opt/wirecloud_instance/data
-            - ./wirecloud-static:/var/www/static
+            - wirecloud-data:/opt/wirecloud_instance/data
+            - wirecloud-static:/var/www/static
         #entrypoint: /bin/bash
         #command: -c "sleep 500"
+
+volumes:
+    elasticsearch-data:
+    postgres-data:
+    wirecloud-data:
+    wirecloud-static:


### PR DESCRIPTION
Using the provided docker-compose.yml and nginx.conf files, the stack fails by throwing the following error:

FATAL: data directory “/var/lib/postgresql/data/pgdata” has wrong ownership
HINT: The server must be started by the user that owns the data directory.

The issue is easily solved by replacing the volumen part in the postgres definition with:

volumes: - /var/lib/postgresql/data

Regards,