### PR TITLE
Allow to retrieve the groups and organizations the user belongs to through the context module

### DIFF
--- a/src/wirecloud/platform/core/plugins.py
+++ b/src/wirecloud/platform/core/plugins.py
@@ -291,9 +291,17 @@ class WirecloudCorePlugin(WirecloudPlugin):
                 'label': _('Is Superuser'),
                 'description': _('Boolean. Designates whether current user is a super user.'),
             },
+            'groups': {
+                'label': _('User Groups'),
+                'description': _('List of the groups the user belongs to.'),
+            },
             'mode': {
                 'label': _('Mode'),
                 'description': _('Rendering mode used by the platform (available modes: classic, smartphone and embedded)'),
+            },
+            'organizations': {
+                'label': _('User Organizations'),
+                'description': _('List of the organizations the user belongs to.'),
             },
             'orientation': {
                 'label': _('Orientation'),
@@ -339,6 +347,8 @@ class WirecloudCorePlugin(WirecloudPlugin):
             'isanonymous': user.is_anonymous,
             'isstaff': user.is_staff,
             'issuperuser': user.is_superuser,
+            'groups': tuple(user.groups.values_list('name', flat=True)),
+            'organizations': tuple(user.groups.filter(organization__isnull=False).values_list('name', flat=True)),
             'mode': 'unknown',
             'realuser': session.get("realuser"),
             'theme': get_active_theme_name(),

--- a/src/wirecloud/platform/core/plugins.py
+++ b/src/wirecloud/platform/core/plugins.py
@@ -619,7 +619,7 @@ class WirecloudCorePlugin(WirecloudPlugin):
                 "wirecloud/user_menu",
             ]
         else:
-            return {}
+            return []
 
     def get_ajax_endpoints(self, view):
         endpoints = (

--- a/src/wirecloud/platform/tests/__init__.py
+++ b/src/wirecloud/platform/tests/__init__.py
@@ -20,7 +20,7 @@
 
 from wirecloud.platform.tests.base import *  # noqa
 from wirecloud.platform.tests.commands import PopuplateCommandTestCase  # noqa
-from wirecloud.platform.tests.plugins import WirecloudPluginTestCase  # noqa
+from wirecloud.platform.tests.plugins import CorePluginTestCase, WirecloudPluginTestCase  # noqa
 from wirecloud.platform.tests.rest_api import AdministrationAPI, ApplicationMashupAPI, ResourceManagementAPI, ExtraApplicationMashupAPI  # noqa
 from wirecloud.platform.tests.search_indexes import *  # noqa
 from wirecloud.platform.tests.selenium import *  # noqa


### PR DESCRIPTION
This PR updates WireCloud code to allow to retrieve the list of groups and organizations the user belongs to using the context module provided by WireCloud (e.g. through `MashupPlatform.context.get` on widgets and operators) 