### PR TITLE
Fix the version of django_compressor to less than 2.4 (close #461)

### DIFF
--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -20,7 +20,7 @@ step, as they will be installed throughout the documentation:**
     - Django 1.9-1.11
     - lxml 2.3.0+
     - django-appconf 1.0.1+
-    - django_compressor 2.0+
+    - django_compressor 2.0-2.3
     - rdflib 3.2.0+
     - requests 2.1.0+
     - futures 2.1.3+ (only on python 2.7)

--- a/src/setup.py
+++ b/src/setup.py
@@ -177,7 +177,7 @@ setup(
         'Django>=1.9,<1.12',
         'lxml>=2.3',
         'django-appconf>=1.0.1,<2.0',
-        'django_compressor>=2.0,<3.0',
+        'django_compressor>=2.0,<2.4',
         'rdflib>=3.2.0',
         'requests>=2.1.0',
         'selenium>=3.4',


### PR DESCRIPTION
This PR limits the version of django-compressor  to less than 2.4.0 and resolves issue #461. It would be great if you could review this PR.

Thank you.