### PR TITLE
Previsualize titlevisible option when in edit mode

### DIFF
--- a/src/wirecloud/defaulttheme/static/css/workspace/widget.scss
+++ b/src/wirecloud/defaulttheme/static/css/workspace/widget.scss
@@ -29,10 +29,11 @@
 }
 
 .wc-widget-heading {
-    position: relative;
+    position: absolute;
     flex-grow: 0;
     display: none;
     width: 100%;
+    z-index: 4;
 
     .wc-moveable-widget > & {
         cursor: -webkit-grab;
@@ -40,6 +41,9 @@
         cursor: grab;
     }
 
+    .wc-titled-widget > & {
+        position: relative;
+    }
     .wc-workspace-editing &,
     .wc-minimized-widget &,
     .wc-titled-widget > & {


### PR DESCRIPTION
When in edit mode, all widgets has a title bar as it is required for displaying edit buttons and so on. This PR updates the editor mode to make title bars to not take up space if the widget is configured to hide the title bar. This way, editors are able to see how is the space going to be used by the widget.