### PR TITLE
Show sidebar widgets when entering edit mode

### DIFF
--- a/src/js_tests/wirecloud/ui/WorkspaceViewSpec.js
+++ b/src/js_tests/wirecloud/ui/WorkspaceViewSpec.js
@@ -1,5 +1,5 @@
 /*
- *     Copyright (c) 2018-2019 Future Internet Consulting and Development Solutions S.L.
+ *     Copyright (c) 2018-2020 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -110,7 +110,13 @@
                 this.findWidget = jasmine.createSpy("findWidget");
                 this.widgets = [];
                 this.dragboard = {
-                    _updateIWidgetSizes: jasmine.createSpy("_updateIWidgetSizes")
+                    _updateIWidgetSizes: jasmine.createSpy("_updateIWidgetSizes"),
+                    leftLayout: {
+                        active: false
+                    },
+                    rightLayout: {
+                        active: false
+                    }
                 };
             });
             utils.inherit(ns.WorkspaceTabView, StyledElements.Tab);

--- a/src/wirecloud/platform/static/js/wirecloud/ui/SidebarLayout.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/SidebarLayout.js
@@ -1,5 +1,5 @@
 /*
- *     Copyright (c) 2018-2019 Future Internet Consulting and Development Solutions S.L.
+ *     Copyright (c) 2018-2020 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -118,7 +118,7 @@
 
     SidebarLayout.prototype.updatePosition = function updatePosition(widget, element) {
         var offset;
-        if (!(this.dragboard.tab.workspace.editing || this.active)) {
+        if (!this.active) {
             offset = -this.getWidth() - this.leftMargin + this.dragboardLeftMargin;
         } else {
             offset = 0;

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WorkspaceTabView.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WorkspaceTabView.js
@@ -1,6 +1,6 @@
 /*
  *     Copyright (c) 2016-2017 CoNWeT Lab., Universidad Politécnica de Madrid
- *     Copyright (c) 2018-2019 Future Internet Consulting and Development Solutions S.L.
+ *     Copyright (c) 2018-2020 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -242,6 +242,11 @@
 
         show: function show() {
             se.Tab.prototype.show.call(this);
+
+            if (this.workspace.editing) {
+                this.dragboard.leftLayout.active = true;
+                this.dragboard.rightLayout.active = true;
+            }
 
             privates.get(this).widgets.forEach(function (widget) {
                 widget.load();

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WorkspaceView.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WorkspaceView.js
@@ -1,6 +1,6 @@
 /*
  *     Copyright 2012-2017 (c) CoNWeT Lab., Universidad Politécnica de Madrid
- *     Copyright (c) 2018-2019 Future Internet Consulting and Development Solutions S.L.
+ *     Copyright (c) 2018-2020 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -53,6 +53,10 @@
             this.activeTab.dragboard._updateIWidgetSizes(true, true);
         });
         this.editButton.addEventListener("active", (button) => {
+            if (this.editing) {
+                this.activeTab.dragboard.leftLayout.active = true;
+                this.activeTab.dragboard.rightLayout.active = true;
+            }
             this.dispatchEvent("editmode", this.editing);
         });
 


### PR DESCRIPTION
This PR changes WireCloud behaviour to display sidebar layouts when entering into edit mode. This also happen when moving between tabs in edit mode. The idea is to allow editors to be aware that there are widgets on those layouts. Editors can hide them again using the handle buttons. 