### PR TITLE
Use a timeout for switching between alternatives

### DIFF
--- a/src/js_tests/styledelements/AlternativesSpec.js
+++ b/src/js_tests/styledelements/AlternativesSpec.js
@@ -1,5 +1,6 @@
 /*
  *     Copyright (c) 2016-2017 CoNWeT Lab., Universidad Politécnica de Madrid
+ *     Copyright (c) 2020 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -50,12 +51,15 @@
             it("should support the full option", function () {
                 var element = new StyledElements.Alternatives({full: false});
                 expect(element.hasClassName('full')).toBe(false);
+                expect(element.alternatives).toEqual({});
             });
 
             it("should support the id option", function () {
                 var element = new StyledElements.Alternatives({id: 'myid'});
                 expect(element.wrapperElement.id).toBe('myid');
+                expect(element.alternatives).toEqual({});
             });
+
         });
 
         describe("clear()", function () {
@@ -93,6 +97,10 @@
                 alt2 = element.createAlternative();
                 expect(element.visibleAlt).toBe(alt1);
 
+                const expected = {};
+                expected[alt1.altId] = alt1;
+                expected[alt2.altId] = alt2;
+                expect(element.alternatives).toEqual(expected);
                 expect(element.alternativeList).toEqual([alt1, alt2]);
             });
 

--- a/src/js_tests/styledelements/UtilsSpec.js
+++ b/src/js_tests/styledelements/UtilsSpec.js
@@ -1,5 +1,6 @@
 /*
  *     Copyright (c) 2016 CoNWeT Lab., Universidad Politécnica de Madrid
+ *     Copyright (c) 2020 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -427,6 +428,89 @@
             });
 
         });
+
+        describe("timeoutPromise(promise, ms, fallback)", () => {
+
+            beforeEach(() => {
+                jasmine.clock().install();
+            });
+
+            afterEach(() => {
+                // Needed because tests can fail
+                jasmine.clock().uninstall();
+            });
+
+            it("should resolve if original promise resolves before timeout", (done) => {
+                let resolve;
+                let original = new Promise((_resolve, reject) => {resolve = _resolve;});
+                let listener = jasmine.createSpy("listener");
+                let p = StyledElements.Utils.timeoutPromise(original, 200);
+                p.then(listener);
+
+                // Allow Promises to react
+                const value = "myvalue";
+                resolve(value);
+                jasmine.clock().uninstall();
+
+                setTimeout(() => {
+                    expect(listener).toHaveBeenCalledWith(value);
+                    done();
+                });
+            });
+
+            it("should reject if original promise rejects before timeout", (done) => {
+                let reject;
+                let original = new Promise((resolve, _reject) => {reject = _reject;});
+                let listener = jasmine.createSpy("listener");
+                let p = StyledElements.Utils.timeoutPromise(original, 200);
+                p.catch(listener);
+
+                // Allow Promises to react
+                const value = "myvalue";
+                reject(value);
+                jasmine.clock().uninstall();
+
+                setTimeout(() => {
+                    expect(listener).toHaveBeenCalledWith(value);
+                    done();
+                });
+            });
+
+            it("should reject on timeout", (done) => {
+                let original = new Promise((resolve, reject) => {});
+                let listener = jasmine.createSpy("listener");
+                let p = StyledElements.Utils.timeoutPromise(original, 200);
+                p.catch(listener);
+
+                jasmine.clock().tick(201);
+                // Allow Promises to react
+                jasmine.clock().uninstall();
+
+                setTimeout(() => {
+                    expect(listener).toHaveBeenCalledWith(jasmine.any(String));
+                    done();
+                });
+            });
+
+            it("should resolve on timeout when providing a fallback", (done) => {
+                let fallback = "fallback";
+                let original = new Promise((resolve, reject) => {});
+                let listener = jasmine.createSpy("listener");
+                let p = StyledElements.Utils.timeoutPromise(original, 200, fallback);
+                p.then(listener);
+
+                jasmine.clock().tick(201);
+                // Allow Promises to react
+                jasmine.clock().uninstall();
+
+                setTimeout(() => {
+                    expect(listener).toHaveBeenCalledWith(fallback);
+                    done();
+                });
+            });
+
+        });
+
         describe("stopPropagationListener(event)", function () {
 
             it("should stop the propagation of the event", function () {

--- a/src/wirecloud/commons/static/js/StyledElements/Alternatives.js
+++ b/src/wirecloud/commons/static/js/StyledElements/Alternatives.js
@@ -336,10 +336,10 @@
                 inAlternative.altId < outAlternative.altId ? 'left' : 'right'
             ]).show();
             p = p.then(function () {
-                return Promise.all([
+                return utils.timeoutPromise(Promise.all([
                     utils.waitTransition(inAlternative.get()),
                     utils.waitTransition(outAlternative.get())
-                ]);
+                ]), 3000, 'timeout');
             }).then(function () {
                 inAlternative.removeClassName('slide');
                 outAlternative.removeClassName('slide left right').hide();
@@ -354,10 +354,10 @@
             inAlternative.addClassName('fade').show();
             outAlternative.addClassName('fade in');
             p = p.then(function () {
-                return Promise.all([
+                return utils.timeoutPromise(Promise.all([
                     utils.waitTransition(inAlternative.get()),
                     utils.waitTransition(outAlternative.get())
-                ]);
+                ]), 3000, 'timeout');
             }).then(function () {
                 inAlternative.removeClassName('fade in');
                 outAlternative.removeClassName('fade').hide();

--- a/src/wirecloud/commons/static/js/StyledElements/Utils.js
+++ b/src/wirecloud/commons/static/js/StyledElements/Utils.js
@@ -1,5 +1,6 @@
 /*
  *     Copyright (c) 2008-2017 CoNWeT Lab., Universidad Politécnica de Madrid
+ *     Copyright (c) 2020 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -952,6 +953,41 @@ if (window.StyledElements == null) {
             setA.add(elem);
         }
         return setA;
+    };
+
+    /**
+     * Creates a new promise that will reject if the original promise does not
+     * resolve or reject in a specific period of time. It is also possible to
+     * use this method to fullfil with a default value if the fallback
+     * parameter is passed.
+     *
+     * @param {Promise} promise original Promise
+     * @param {Number} ms time to wait until the promise should be rejected or
+     *        resolved
+     * @param {*} [fallback] if provided, the created promise will resolve
+     *        instead of being rejected. fallback value will be used as Promise
+     *        value.
+     *
+     * @returns {Promise}
+     */
+    Utils.timeoutPromise = function timeoutPromise(promise, ms, fallback) {
+        // Create a promise that resolves/rejects in <ms> milliseconds
+        let timeout = new Promise((resolve, reject) => {
+            let id = setTimeout(() => {
+                clearTimeout(id);
+                if (fallback != null) {
+                    resolve(fallback);
+                } else {
+                    reject('Timed out in ' + ms + 'ms.')
+                }
+            }, ms);
+        });
+
+        // Returns a race between our timeout and the passed in promise
+        return Promise.race([
+            promise,
+            timeout
+        ]);
     };
 
     Utils.waitTransition = function waitTransition(element) {


### PR DESCRIPTION
Currently, `StyledElements.Alternatives` code relies on `transitionend` events to detect when animations have finished. This PR makes `StyledElements.Alternatives` to use a timeout promise to make code work even if those events are not raised.