### PR TITLE
Add an editing variable to the workspace context

### DIFF
--- a/src/js_tests/wirecloud/WorkspaceSpec.js
+++ b/src/js_tests/wirecloud/WorkspaceSpec.js
@@ -152,9 +152,17 @@
 
             // Simulate Wirecloud.init has been called
             Wirecloud.constants.WORKSPACE_CONTEXT = {
-                "title": {
-                    "description": "Current title of the workspace",
-                    "label": "Title"
+                "description": {
+                    "description": "Workspace's short description",
+                    "label": "Description"
+                },
+                'editing': {
+                    "label": "Editing mode",
+                    "description": "Boolean. Designates whether the workspace is in editing mode."
+                },
+                "longdescription": {
+                    "description": "Workspace's long description",
+                    "label": "Long Description"
                 },
                 "name": {
                     "description": "Current name of the workspace",
@@ -164,13 +172,9 @@
                     "description": "Workspace's owner username",
                     "label": "Owner"
                 },
-                "description": {
-                    "description": "Workspace's short description",
-                    "label": "Description"
-                },
-                "longdescription": {
-                    "description": "Workspace's long description",
-                    "label": "Long Description"
+                "title": {
+                    "description": "Current title of the workspace",
+                    "label": "Title"
                 }
             };
         });

--- a/src/wirecloud/platform/core/plugins.py
+++ b/src/wirecloud/platform/core/plugins.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2012-2017 CoNWeT Lab., Universidad Politécnica de Madrid
-# Copyright (c) 2018-2019 Future Internet Consulting and Development Solutions S.L.
+# Copyright (c) 2018-2020 Future Internet Consulting and Development Solutions S.L.
 
 # This file is part of Wirecloud.
 
@@ -358,6 +358,14 @@ class WirecloudCorePlugin(WirecloudPlugin):
 
     def get_workspace_context_definitions(self):
         return {
+            'description': {
+                'label': _('Description'),
+                'description': _("Short description of the workspace without formating"),
+            },
+            'editing': {
+                'label': _('Editing mode'),
+                'description': _('Boolean. Designates whether the workspace is in editing mode.'),
+            },
             'title': {
                 'label': _('Title'),
                 'description': _('Current title of the workspace'),
@@ -370,20 +378,10 @@ class WirecloudCorePlugin(WirecloudPlugin):
                 'label': _('Owner'),
                 'description': _("Workspace's owner username"),
             },
-            'description': {
-                'label': _('Description'),
-                'description': _("Short description of the workspace without formating"),
-            },
             'longdescription': {
                 'label': _('Long description'),
                 'description': _("Detailed workspace's description. This description can contain formatting."),
             }
-        }
-
-    def get_workspace_context_current_values(self, workspace, user):
-        return {
-            'name': workspace.name,
-            'owner': workspace.creator.username,
         }
 
     def get_workspace_preferences(self):

--- a/src/wirecloud/platform/static/js/wirecloud/Workspace.js
+++ b/src/wirecloud/platform/static/js/wirecloud/Workspace.js
@@ -1,6 +1,6 @@
 /*
  *     Copyright (c) 2016-2017 CoNWeT Lab., Universidad Politécnica de Madrid
- *     Copyright (c) 2018 Future Internet Consulting and Development Solutions S.L.
+ *     Copyright (c) 2018-2020 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -218,11 +218,12 @@
         });
 
         this.contextManager.modify({
-            title: data.title != null && data.title.trim() !== "" ? data.title : data.name,
+            description: data.description,
+            editing: false,
+            longdescription: data.longdescription,
             name: data.name,
             owner: data.owner,
-            description: data.description,
-            longdescription: data.longdescription
+            title: data.title != null && data.title.trim() !== "" ? data.title : data.name
         });
 
         /* FIXME */

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WorkspaceView.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WorkspaceView.js
@@ -57,7 +57,9 @@
                 this.activeTab.dragboard.leftLayout.active = true;
                 this.activeTab.dragboard.rightLayout.active = true;
             }
-            this.model.contextManager.modify({editing: this.editing});
+            if (this.model != null) {
+                this.model.contextManager.modify({editing: this.editing});
+            }
             this.dispatchEvent("editmode", this.editing);
         });
 

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WorkspaceView.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WorkspaceView.js
@@ -57,6 +57,7 @@
                 this.activeTab.dragboard.leftLayout.active = true;
                 this.activeTab.dragboard.rightLayout.active = true;
             }
+            this.model.contextManager.modify({editing: this.editing});
             this.dispatchEvent("editmode", this.editing);
         });
 

--- a/src/wirecloud/platform/tests/plugins.py
+++ b/src/wirecloud/platform/tests/plugins.py
@@ -303,10 +303,7 @@ class CorePluginTestCase(TestCase):
         user = Mock()
         workspace = Mock(name="myworkspace", owner=Mock(username="owner"))
         context = self.plugin.get_workspace_context_current_values(workspace, user)
-        self.assertEqual(context, {
-            "name": workspace.name,
-            "owner": workspace.creator.username
-        })
+        self.assertEqual(type(context), dict)
 
     def test_get_widget_api_extensions_no_feature(self):
         scripts = self.plugin.get_widget_api_extensions("classic", [])


### PR DESCRIPTION
This PR adds an editing variable into workspace context allowing widgets to know if user is editing the workspace.