### PR TITLE
Support for Rol-Group mapping on the FIWARE idm backend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+    -   id: flake8
+-   repo: local
+    hooks:
+    -   id: eslint
+        name: eslint
+        entry: eslint -c src/.eslintrc
+        language: node
+        'types': [javascript]
+        files: 'src/wirecloud/(commons|platform)/static/js/.*'

--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -903,7 +903,7 @@ AUTHENTICATION_BACKENDS = (
 ```
 
 > **Note**: Django supports several authentication backends (see this
-> [link](https://docs.djangoproject.com/en/1.11/topics/auth/customizing/#specifying-authentication-backends) for more
+> [link](https://docs.djangoproject.com/en/2.2/topics/auth/customizing/#specifying-authentication-backends) for more
 > details). For example, you can continue authenticating users using the local db by also listing
 > `django.contrib.auth.backends.ModelBackend` in `AUTHENTICATION_BACKENDS`, although this will require extra
 > configuration not documented in this guide.
@@ -936,7 +936,28 @@ SOCIAL_AUTH_FIWARE_SECRET = "a6ded8771f7438ce430dd93067a328fd282c6df8c6c793fc822
     portals at the same time the user sign out from WireCloud, providing a single sign out experience. This setting is
     also used for building the navigation bar.
 
-<zbr>6.  Run `python manage.py migrate; python manage.py collectstatic --noinput`
+<zbr>6.   [Optional]: Enable role-group synchronization by adding
+    `wirecloud.fiware.social_auth_backend.sync_role_groups` into social auth pipeline. By enabling this role-group
+    synchronization, each role configured on the KeyRock application will be associated with a WireCloud group, users
+    will be associated with those groups following KeyRock instructions. This is the default social auth pipeline with
+    role-group synchronization enabled:
+
+```python
+SOCIAL_AUTH_PIPELINE = (
+    'social_core.pipeline.social_auth.social_details',
+    'social_core.pipeline.social_auth.social_uid',
+    'social_core.pipeline.social_auth.auth_allowed',
+    'social_core.pipeline.social_auth.social_user',
+    'social_core.pipeline.user.get_username',
+    'social_core.pipeline.user.create_user',
+    'social_core.pipeline.social_auth.associate_user',
+    'social_core.pipeline.social_auth.load_extra_data',
+    'social_core.pipeline.user.user_details',
+    'wirecloud.fiware.social_auth_backend.sync_role_groups',
+)
+```
+
+<zbr>7.  Run `python manage.py migrate; python manage.py collectstatic --noinput`
 
 [keyrock's user and programmers guide]:
     https://fi-ware-idm.readthedocs.org/en/latest/user_guide/#registering-an-application

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,13 +1,13 @@
 ## Supported browsers
 
-WireCloud 1.3 supports the following desktop browsers:
+WireCloud 1.4 supports the following desktop browsers:
 
--   Firefox 52+
--   Chrome 57+
--   Safari 10.1+
--   Opera 43+
+-   Firefox 60+
+-   Chrome 64+
+-   Safari 11+
+-   Opera 48+
 
-WireCloud 1.3 also works on the mobile version of the previous browsers, except the wiring editor currently does not
+WireCloud 1.4 also works on the mobile version of the previous browsers, except the wiring editor currently does not
 work with touch screens.
 
 > **Note:** Although WireCloud supports those browsers, some widgets and operators may not support all of them. Read


### PR DESCRIPTION
This PR adds support for mapping roles coming from KeyRock server into local groups.