### PR TITLE
Allow to share dashboards with groups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+    -   id: flake8
+-   repo: local
+    hooks:
+    -   id: eslint
+        name: eslint
+        entry: eslint -c src/.eslintrc
+        language: node
+        'types': [javascript]
+        files: 'src/wirecloud/(commons|platform)/static/js/.*'

--- a/src/js_tests/styledelements/PopupMenuBaseSpec.js
+++ b/src/js_tests/styledelements/PopupMenuBaseSpec.js
@@ -1,5 +1,5 @@
 /*
- *     Copyright (c) 2019 Future Internet Consulting and Development Solutions S.L.
+ *     Copyright (c) 2019-2020 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -46,7 +46,7 @@
 
         });
 
-        describe("append()", () => {
+        describe("append(child)", () => {
 
             var menu;
 
@@ -108,6 +108,23 @@
                 expect(menu.activeItem).toBe(item);
                 expect(menu.firstEnabledItem).toBe(item);
                 expect(menu.lastEnabledItem).toBe(item);
+            });
+
+            it("should work when adding a disabled item while oneActiveAtLeast option is used", () => {
+                var listener = jasmine.createSpy("listener");
+                menu = new se.PopupMenuBase({oneActiveAtLeast: true});
+                var ref_element = new se.Button();
+                menu.show(ref_element);
+                menu.addEventListener("itemOver", listener);
+                var item = new se.MenuItem("Entry");
+                item.enabled = false;
+
+                expect(menu.append(item)).toBe(menu);
+
+                expect(listener).not.toHaveBeenCalled();
+                expect(menu.activeItem).toBe(null);
+                expect(menu.firstEnabledItem).toBe(null);
+                expect(menu.lastEnabledItem).toBe(null);
             });
 
             it("should add dynamic generated items", () => {

--- a/src/js_tests/styledelements/UtilsSpec.js
+++ b/src/js_tests/styledelements/UtilsSpec.js
@@ -457,6 +457,19 @@
 
         });
 
+        describe("setupdate(setA, setB)", () => {
+
+            it("should add all elements from setB into setA", () => {
+                let setA = new Set([1, 2, 3]);
+                let setB = new Set([5, 6, 7]);
+
+                expect(utils.setupdate(setA, setB)).toBe(setA);
+
+                expect(setA).toEqual(new Set([1, 2, 3, 5, 6, 7]));
+            });
+
+        });
+
         describe("timeoutPromise(promise, ms, fallback)", () => {
 
             beforeEach(() => {

--- a/src/js_tests/styledelements/UtilsSpec.js
+++ b/src/js_tests/styledelements/UtilsSpec.js
@@ -23,7 +23,7 @@
 /* globals StyledElements */
 
 
-(function () {
+(function (utils) {
 
     "use strict";
 
@@ -429,6 +429,34 @@
 
         });
 
+        describe("removeFromArray(arr, element)", () => {
+
+            it("should remove basic primitives from an array", () => {
+                let arr = [1, 2, 3];
+
+                utils.removeFromArray(arr, 2);
+
+                expect(arr).toEqual([1, 3]);
+            });
+
+            it("should remove only first element", () => {
+                let arr = [1, 2, 3, 2];
+
+                utils.removeFromArray(arr, 2);
+
+                expect(arr).toEqual([1, 3, 2]);
+            });
+
+            it("should work if element is not found", () => {
+                let arr = [1, 2, 3];
+
+                utils.removeFromArray(arr, 4);
+
+                expect(arr).toEqual([1, 2, 3]);
+            });
+
+        });
+
         describe("timeoutPromise(promise, ms, fallback)", () => {
 
             beforeEach(() => {
@@ -631,4 +659,4 @@
 
     });
 
-})();
+})(StyledElements.Utils);

--- a/src/js_tests/wirecloud/ui/WorkspaceTabViewSpec.js
+++ b/src/js_tests/wirecloud/ui/WorkspaceTabViewSpec.js
@@ -1,5 +1,5 @@
 /*
- *     Copyright (c) 2018-2019 Future Internet Consulting and Development Solutions S.L.
+ *     Copyright (c) 2018-2020 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -484,7 +484,7 @@
             });
 
             it("should handle changes to the baselayout preference", () => {
-                callEventListener(model.preferences, "pre-commit", {"baselayout": 5});
+                callEventListener(model.preferences, "post-commit", {"baselayout": 5});
 
                 expect(tab.dragboard._updateBaseLayout).toHaveBeenCalledWith();
             });

--- a/src/wirecloud/commons/static/js/StyledElements/PopupMenuBase.js
+++ b/src/wirecloud/commons/static/js/StyledElements/PopupMenuBase.js
@@ -196,7 +196,7 @@
         if (this.isVisible()) {
             display.call(this, child);
 
-            if (this._activeMenuItem == null && this.oneActiveAtLeast) {
+            if (this._activeMenuItem == null && this.oneActiveAtLeast && this._enabledItems.length > 0) {
                 activateMenuItem.call(this, this._enabledItems[0]);
             }
         }

--- a/src/wirecloud/commons/static/js/StyledElements/Utils.js
+++ b/src/wirecloud/commons/static/js/StyledElements/Utils.js
@@ -946,7 +946,9 @@ if (window.StyledElements == null) {
     };
 
     /**
+     * Updates a set by adding all the elements of another set.
      *
+     * @since 0.11.0
      */
     Utils.setupdate = function setupdate(setA, setB) {
         for (var elem of setB) {
@@ -1011,6 +1013,11 @@ if (window.StyledElements == null) {
         });
     };
 
+    /**
+     * Removes an element from an array.
+     *
+     * @since 0.11.0
+     */
     Utils.removeFromArray = function removeFromArray(arr, element) {
         let index = arr.indexOf(element);
         if (index !== -1) {

--- a/src/wirecloud/commons/static/js/StyledElements/Utils.js
+++ b/src/wirecloud/commons/static/js/StyledElements/Utils.js
@@ -1011,6 +1011,13 @@ if (window.StyledElements == null) {
         });
     };
 
+    Utils.removeFromArray = function removeFromArray(arr, element) {
+        let index = arr.indexOf(element);
+        if (index !== -1) {
+            arr.splice(index, 1);
+        }
+    };
+
     StyledElements.Utils = Utils;
 
 })();

--- a/src/wirecloud/commons/static/js/wirecloud/ui/UserGroupTypeahead.js
+++ b/src/wirecloud/commons/static/js/wirecloud/ui/UserGroupTypeahead.js
@@ -1,0 +1,73 @@
+/*
+ *     Copyright (c) 2020 Future Internet Consulting and Development Solutions S.L.
+ *
+ *     This file is part of Wirecloud Platform.
+ *
+ *     Wirecloud Platform is free software: you can redistribute it and/or
+ *     modify it under the terms of the GNU Affero General Public License as
+ *     published by the Free Software Foundation, either version 3 of the
+ *     License, or (at your option) any later version.
+ *
+ *     Wirecloud is distributed in the hope that it will be useful, but WITHOUT
+ *     ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *     FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+ *     License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with Wirecloud Platform.  If not, see
+ *     <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/* globals StyledElements, Wirecloud */
+
+
+(function (ns, se, utils) {
+
+    "use strict";
+
+    const ICON_MAPPING = {
+        group: "users",
+        organization: "building",
+        user: "user"
+    };
+
+    ns.UserGroupTypeahead = function UserGroupTypeahead(options) {
+        options = utils.merge(utils.clone(defaults), options);
+
+        se.Typeahead.call(this, {
+            autocomplete: options.autocomplete,
+            lookup: searchForUserGroup,
+            build: function build(typeahead, data) {
+                return {
+                    value: data.name,
+                    title: data.fullname || data.name,
+                    description: data.name,
+                    iconClass: "fas fa-" + ICON_MAPPING[data.type],
+                    context: data
+                };
+            }
+        });
+    };
+    utils.inherit(ns.UserGroupTypeahead, se.Typeahead);
+
+    // =========================================================================
+    // PRIVATE MEMBERS
+    // =========================================================================
+
+    var defaults = {
+        autocomplete: true
+    };
+
+    var searchForUserGroup = function searchForUserGroup(querytext, next) {
+        return Wirecloud.io.makeRequest(Wirecloud.URLs.SEARCH_SERVICE, {
+            parameters: {namespace: 'usergroup', q: querytext},
+            method: 'GET',
+            contentType: 'application/json',
+            requestHeaders: {'Accept': 'application/json'}
+        }).then((response) => {
+            next(JSON.parse(response.responseText).results);
+        });
+    };
+
+})(Wirecloud.ui, StyledElements, StyledElements.Utils);

--- a/src/wirecloud/commons/tests/__init__.py
+++ b/src/wirecloud/commons/tests/__init__.py
@@ -3,7 +3,7 @@ from wirecloud.commons.tests.basic_views import BasicViewTestCase
 from wirecloud.commons.tests.commands import CreateOrganizationCommandTestCase
 from wirecloud.commons.tests.fields import JSONFieldTestCase
 from wirecloud.commons.tests.middleware import LocaleMiddlewareTestCase, URLMiddlewareTestCase
-from wirecloud.commons.tests.search_indexes import QueryParserTestCase, SearchAPITestCase, GroupIndexTestCase, UserIndexTestCase
+from wirecloud.commons.tests.search_indexes import QueryParserTestCase, SearchAPITestCase, GroupIndexTestCase, UserGroupIndexTestCase, UserIndexTestCase
 from wirecloud.commons.tests.template import TemplateUtilsTestCase
 from wirecloud.commons.tests.utils import GeneralUtilsTestCase, HTMLCleanupTestCase, WGTTestCase, HTTPUtilsTestCase
 
@@ -14,5 +14,5 @@ __all__ = (
     "JSONFieldTestCase", "LocaleMiddlewareTestCase", "QueryParserTestCase",
     "ResetSearchIndexesCommandTestCase", "SearchAPITestCase",
     "StartprojectCommandTestCase", "TemplateUtilsTestCase", "URLMiddlewareTestCase",
-    "UserIndexTestCase", "WGTTestCase"
+    "UserGroupIndexTestCase", "UserIndexTestCase", "WGTTestCase"
 )

--- a/src/wirecloud/commons/tests/search_indexes.py
+++ b/src/wirecloud/commons/tests/search_indexes.py
@@ -237,9 +237,7 @@ class UserIndexTestCase(WirecloudTestCase, TestCase):
             cleanUserResults(
                 Mock(get_stored_fields=Mock(return_value={
                     "fullname": "Full Name",
-                    "fullname_orderby": "Full Name",
-                    "username": "username",
-                    "username_orderby": "username",
+                    "name": "username",
                     "organization": False,
                 })),
                 Mock()
@@ -256,9 +254,7 @@ class UserIndexTestCase(WirecloudTestCase, TestCase):
             cleanUserResults(
                 Mock(get_stored_fields=Mock(return_value={
                     "fullname": "Organization Name",
-                    "fullname_orderby": "Organization Name",
-                    "username": "username",
-                    "username_orderby": "username",
+                    "name": "username",
                     "organization": True,
                 })),
                 Mock()

--- a/src/wirecloud/platform/core/plugins.py
+++ b/src/wirecloud/platform/core/plugins.py
@@ -570,6 +570,7 @@ class WirecloudCorePlugin(WirecloudPlugin):
                 'js/wirecloud/ui/RenameWindowMenu.js',
                 'js/wirecloud/ui/UpgradeWindowMenu.js',
                 'js/wirecloud/ui/UserTypeahead.js',
+                'js/wirecloud/ui/UserGroupTypeahead.js',
             ) + WIRING_EDITOR_FILES + TUTORIAL_FILES
 
             if view != 'embedded':

--- a/src/wirecloud/platform/preferences/tests.py
+++ b/src/wirecloud/platform/preferences/tests.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2019 Future Internet Consulting and Development Solutions S.L.
+# Copyright (c) 2019-2020 Future Internet Consulting and Development Solutions S.L.
 
 # This file is part of Wirecloud.
 
@@ -59,9 +59,9 @@ class WorkspacePreferencesTestCase(TestCase):
         self.assertEqual(response.status_code, 204)
 
     @parameterized.expand([
-        ({"value": '[{"username": "user1", "accessLevel": "read"}, {"username": "org1"}]'},),
-        ('[{"username": "user1", "accessLevel": "read"}, {"username": "org1"}]',),
-        ('[{"username": "user1", "accessLevel": "read"}, {"username": "org1"}, {"username": "inexistent"}, {"username": false}]',),
+        ({"value": '[{"name": "user1", "type": "user", "accessLevel": "read"}, {"name": "org1", "type": "organization"}]'},),
+        ('[{"name": "user1", "type": "user", "accessLevel": "read"}, {"name": "org1", "type": "organization"}]',),
+        ('[{"name": "user1", "type": "user", "accessLevel": "read"}, {"name": "org1", "type": "organization"}, {"name": "inexistent", "type": "user"}, {"name": false}]',),
     ])
     def test_workspace_preference_collection_post_sharelist(self, WorkspacePreference, User, cache, parse_json_request, get_object_or_404, value):
         workspace = get_object_or_404()
@@ -90,7 +90,7 @@ class WorkspacePreferencesTestCase(TestCase):
         workspace = get_object_or_404()
         workspace.is_editable_by.return_value = True
         parse_json_request.return_value = {
-            "sharelist": '[{"username": "user1", "accessLevel": "write"}]',
+            "sharelist": '[{"name": "user1", "type": "user", "accessLevel": "write"}]',
         }
         request = Mock(META={
             "CONTENT_TYPE": "application/json",

--- a/src/wirecloud/platform/preferences/views.py
+++ b/src/wirecloud/platform/preferences/views.py
@@ -52,12 +52,7 @@ def update_preferences(user, preferences_json):
 
 
 def parseValues(values):
-    _values = {}
-
-    for value in values:
-        _values[value.name] = {'inherit': False, 'value': value.value}
-
-    return _values
+    return {value.name: {'inherit': False, 'value': value.value} for value in values}
 
 
 def parseInheritableValues(values):

--- a/src/wirecloud/platform/preferences/views.py
+++ b/src/wirecloud/platform/preferences/views.py
@@ -307,6 +307,8 @@ class WorkspacePreferencesCollection(Resource):
                     except (KeyError, Group.DoesNotExist):
                         continue
 
+            del preferences_json['sharelist']
+
         if 'public' in preferences_json and (type(preferences_json['public']) or "value" in preferences_json['public']):
             save_workspace = True
             if type(preferences_json['public']) == str:

--- a/src/wirecloud/platform/static/js/wirecloud/TabPreferences.js
+++ b/src/wirecloud/platform/static/js/wirecloud/TabPreferences.js
@@ -1,5 +1,6 @@
 /*
  *     Copyright (c) 2008-2016 CoNWeT Lab., Universidad Politécnica de Madrid
+ *     Copyright (c) 2020 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -35,7 +36,7 @@
             }
         });
 
-        this.tab.workspace.preferences.addEventListener('pre-commit', this._handleParentChanges);
+        this.tab.workspace.preferences.addEventListener('post-commit', this._handleParentChanges);
     };
     utils.inherit(TabPreferences, Wirecloud.Preferences);
 
@@ -52,7 +53,7 @@
     };
 
     TabPreferences.prototype.destroy = function destroy() {
-        this.tab.workspace.preferences.removeEventListener('pre-commit', this._handleParentChanges);
+        this.tab.workspace.preferences.removeEventListener('post-commit', this._handleParentChanges);
         Wirecloud.Preferences.prototype.destroy.call(this);
     };
 

--- a/src/wirecloud/platform/static/js/wirecloud/Workspace.js
+++ b/src/wirecloud/platform/static/js/wirecloud/Workspace.js
@@ -104,6 +104,13 @@
             },
             /**
              * @memberOf Wirecloud.Workspace#
+             * @type {Array.<Group>}
+             */
+            groups: {
+                value: data.groups
+            },
+            /**
+             * @memberOf Wirecloud.Workspace#
              * @type {String}
              */
             id: {

--- a/src/wirecloud/platform/static/js/wirecloud/WorkspacePreferences.js
+++ b/src/wirecloud/platform/static/js/wirecloud/WorkspacePreferences.js
@@ -1,5 +1,6 @@
 /*
  *     Copyright (c) 2008-2016 CoNWeT Lab., Universidad Politécnica de Madrid
+ *     Copyright (c) 2020 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -30,7 +31,7 @@
         Wirecloud.Preferences.call(this, definitions, values);
         this._workspace = workspace;
 
-        Wirecloud.preferences.addEventListener('pre-commit', this._handleParentChanges);
+        Wirecloud.preferences.addEventListener('post-commit', this._handleParentChanges);
     };
     utils.inherit(WorkspacePreferences, Wirecloud.Preferences);
 
@@ -47,7 +48,7 @@
     };
 
     WorkspacePreferences.prototype.destroy = function destroy() {
-        Wirecloud.preferences.removeEventListener('pre-commit', this._handleParentChanges);
+        Wirecloud.preferences.removeEventListener('post-commit', this._handleParentChanges);
 
         Wirecloud.Preferences.prototype.destroy.call(this);
         this._workspace = null;

--- a/src/wirecloud/platform/static/js/wirecloud/ui/SharingWindowMenu.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/SharingWindowMenu.js
@@ -1,6 +1,6 @@
 /*
  *     Copyright (c) 2015-2016 CoNWeT Lab., Universidad Politécnica de Madrid
- *     Copyright (c) 2018-2019 Future Internet Consulting and Development Solutions S.L.
+ *     Copyright (c) 2018-2020 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -58,10 +58,10 @@
         subtitle2.textContent = utils.gettext("Users and groups with access");
         this.windowContent.appendChild(subtitle2);
 
-        this.inputSearch = new se.TextField({placeholder: utils.gettext("Add a person or an organization"), class: "wc-dashboard-share-input"});
+        this.inputSearch = new se.TextField({placeholder: utils.gettext("Add a person, a group or an organization"), class: "wc-dashboard-share-input"});
         this.inputSearch.appendTo(this.windowContent);
 
-        this.inputSearchTypeahead = new Wirecloud.ui.UserTypeahead({autocomplete: false});
+        this.inputSearchTypeahead = new Wirecloud.ui.UserGroupTypeahead({autocomplete: false});
 
         this.inputSearchTypeahead.bind(this.inputSearch);
         this.inputSearchTypeahead.addEventListener('select', (typeahead, menuItem) => {
@@ -71,11 +71,26 @@
         this.userGroup = new se.Container({class: "wc-dashboard-share-list"});
         this.userGroup.appendTo(this.windowContent);
 
-        this.sharingUsers = {};
+        this.users = {};
+        this.groups = {};
+        this.sharelist = [];
 
-        for (i = 0; i < workspace.model.users.length; i++) {
-            appendUser.call(this, workspace.model.users[i]);
-        }
+        workspace.model.users.forEach((user) => {
+            appendUser.call(this, {
+                accesslevel: user.accesslevel,
+                fullname: user.fullname,
+                name: user.username,
+                type: user.organization ? "organization" : "user"
+            });
+        });
+        workspace.model.groups.forEach((group) => {
+            appendUser.call(this, {
+                accesslevel: group.accesslevel,
+                name: group.name,
+                organization: false,
+                type: "group"
+            });
+        });
 
         // windowmenu - footer
 
@@ -112,16 +127,28 @@
         this.btnAccept.disable().addClassName('busy');
         this.btnCancel.disable();
 
-        const sharelist = Object.values(this.sharingUsers);
         this.workspace.model.preferences.set({
             public: {value: this.visibilityOptions.value === "public" || this.visibilityOptions.value === "public-auth"},
             requireauth: {value: this.visibilityOptions.value !== "public"},
-            sharelist: {value: sharelist}
+            sharelist: {value: this.sharelist}
         }).then(
             () => {
                 this.workspace.model.users.length = 0;
-                sharelist.forEach((user) => {
-                    this.workspace.model.users.push(user);
+                this.workspace.model.groups.length = 0;
+                this.sharelist.forEach((item) => {
+                    if (item.type === "group") {
+                        this.workspace.model.groups.push({
+                            name: item.name,
+                            accesslevel: item.accesslevel
+                        });
+                    } else {
+                        this.workspace.model.users.push({
+                            fullname: item.fullname,
+                            username: item.name,
+                            organization: item.organization,
+                            accesslevel: item.accesslevel
+                        });
+                    }
                 });
 
                 this._closeListener();
@@ -152,56 +179,53 @@
     };
 
     var appendUser = function appendUser(data) {
-        var createdElement;
-
-        if (data.username in this.sharingUsers) {
+        if (
+            (data.type === "user" || data.type === "organization") && data.name in this.users
+            || data.type === "group" && data.name in this.groups
+        ) {
             // This user is already taken.
             return this;
         }
-        this.sharingUsers[data.username] = data;
+        this[data.type === "group" ? "groups" : "users"][data.name] = data;
+        this.sharelist.push(data);
 
-        var fullname = data.fullname;
-        if (data.username === Wirecloud.contextManager.get('username')) {
-            fullname = utils.interpolate(utils.gettext("%(fullname)s (You)"), {fullname: data.fullname});
+        let fullname = data.fullname || data.name;
+        if (data.name === Wirecloud.contextManager.get('username')) {
+            fullname = utils.interpolate(utils.gettext("%(fullname)s (You)"), {fullname: fullname});
             data.accesslevel = "owner";
         } else {
             data.accesslevel = "read";
         }
 
         let template = Wirecloud.currentTheme.templates['wirecloud/workspace/sharing_user'];
-        createdElement = builder.parse(template, {
+        let createdElement = builder.parse(template, {
             fullname: fullname,
             icon: function () {
                 var icon = document.createElement('i');
-                icon.className = data.organization ? "fa fa-building fa-stack-1x" : "fa fa-user fa-stack-1x";
+                icon.className = "fas fa-" + (data.type === "group" ? "users" : (data.type === "organization" ? "building" : "user")) + " fa-stack-1x";
                 return icon;
             },
-            username: data.username,
-            permission: function () {
+            username: data.name,
+            permission: () => {
                 var span = document.createElement('span');
-
-                if (data.accesslevel === 'owner') {
-                    span.textContent = utils.gettext("Owner");
-                } else {
-                    span.textContent = utils.gettext("Can view");
-                }
-
+                span.textContent = data.accesslevel === 'owner' ? utils.gettext("Owner") : utils.gettext("Can view");
                 return span;
             },
-            btndelete: function () {
-                var button = new se.Button({class: "btn-remove-user", plain: true, iconClass: "fa fa-remove", title: utils.gettext("Remove")});
+            btndelete: () => {
+                var button = new se.Button({class: "btn-remove-user", plain: true, iconClass: "fas fa-times", title: utils.gettext("Remove")});
 
                 if (data.accesslevel === 'owner') {
                     button.disable();
                 } else {
-                    button.addEventListener('click', function () {
+                    button.addEventListener('click', () => {
                         this.userGroup.removeChild(createdElement);
-                        delete this.sharingUsers[data.username];
-                    }.bind(this));
+                        delete this[data.type === "group" ? "groups" : "users"][data.name];
+                        utils.removeFromArray(this.sharelist, data);
+                    });
                 }
 
                 return button;
-            }.bind(this)
+            }
         }).elements[1];
 
         this.userGroup.appendChild(createdElement);

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WorkspaceTabView.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WorkspaceTabView.js
@@ -147,7 +147,7 @@
         }).children[1];
         this.appendChild(this.initialMessage);
 
-        this.model.preferences.addEventListener('pre-commit', on_change_preferences.bind(this));
+        this.model.preferences.addEventListener('post-commit', on_change_preferences.bind(this));
         this.model.widgets.forEach(_create_widget, this);
         this.initialMessage.hidden = !this.workspace.model.isAllowed("edit") || this.widgets.length > 0;
 

--- a/src/wirecloud/platform/tests/__init__.py
+++ b/src/wirecloud/platform/tests/__init__.py
@@ -30,5 +30,5 @@ from wirecloud.platform.markets.tests import *  # noqa
 from wirecloud.platform.preferences.tests import *  # noqa
 from wirecloud.platform.wiring.tests import *  # noqa
 from wirecloud.platform.widget.tests import CodeTransformationTestCase, WidgetModuleTestCase  # noqa
-from wirecloud.platform.workspace.tests import WorkspaceMigrationsTestCase, WorkspaceTestCase, WorkspaceCacheTestCase, ParameterizedWorkspaceParseTestCase, ParameterizedWorkspaceGenerationTestCase  # noqa
+from wirecloud.platform.workspace.tests import WorkspaceMigrationsTestCase, WorkspaceTestCase, WorkspaceUtilsTestCase, WorkspaceCacheTestCase, ParameterizedWorkspaceParseTestCase, ParameterizedWorkspaceGenerationTestCase  # noqa
 from wirecloud.proxy.tests import ProxyTests, ProxySecureDataTests  # noqa

--- a/src/wirecloud/platform/workspace/utils.py
+++ b/src/wirecloud/platform/workspace/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2008-2017 CoNWeT Lab., Universidad Politécnica de Madrid
-# Copyright (c) 2019 Future Internet Consulting and Development Solutions S.L.
+# Copyright (c) 2019-2020 Future Internet Consulting and Development Solutions S.L.
 
 # This file is part of Wirecloud.
 
@@ -377,19 +377,33 @@ def _get_global_workspace_data(workspaceDAO, user):
     data_ret['preferences'] = preferences
 
     data_ret['users'] = []
+    data_ret['groups'] = []
 
-    for u in workspaceDAO.users.all():
-        try:
-            is_organization = u.organization is not None
-        except Organization.DoesNotExist:
-            is_organization = False
+    if workspaceDAO.creator == user:
+        for u in workspaceDAO.users.all():
+            try:
+                is_organization = u.organization is not None
+            except Organization.DoesNotExist:
+                is_organization = False
 
-        data_ret['users'].append({
-            "fullname": u.get_full_name(),
-            "username": u.username,
-            "organization": is_organization,
-            "accesslevel": "owner" if workspaceDAO.creator == u else "read",
-        })
+            data_ret['users'].append({
+                "fullname": u.get_full_name(),
+                "username": u.username,
+                "organization": is_organization,
+                "accesslevel": "owner" if workspaceDAO.creator == u else "read",
+            })
+
+        for g in workspaceDAO.groups.all():
+            try:
+                is_organization = g.organization is not None
+            except Organization.DoesNotExist:
+                is_organization = False
+
+            if is_organization is False:
+                data_ret['groups'].append({
+                    "name": g.name,
+                    "accesslevel": "read",
+                })
 
     # Process forced variable values
     concept_values = get_context_values(workspaceDAO, user)

--- a/src/wirecloud/platform/workspace/utils.py
+++ b/src/wirecloud/platform/workspace/utils.py
@@ -554,21 +554,45 @@ def get_iwidget_data(iwidget, workspace, cache_manager=None, user=None):
     return data_ret
 
 
-def create_workspace(owner, f=None, mashup=None, new_name=None, new_title=None, preferences={}, searchable=True, public=False):
+def create_workspace(owner, mashup, new_name=None, new_title=None, preferences={}, searchable=True, public=False, allow_renaming=False, dry_run=False):
 
-    from wirecloud.platform.workspace.mashupTemplateParser import buildWorkspaceFromTemplate
+    from wirecloud.platform.workspace.mashupTemplateParser import buildWorkspaceFromTemplate, check_mashup_dependencies
 
-    if mashup is not None and f is not None:
-        raise Exception
+    if type(mashup) == str:
+        values = mashup.split('/', 3)
+        if len(values) != 3:
+            raise ValueError(_('invalid mashup id'))
 
-    if f is not None:
+        (mashup_vendor, mashup_name, mashup_version) = values
+        try:
+            resource = CatalogueResource.objects.get(vendor=mashup_vendor, short_name=mashup_name, version=mashup_version)
+            if not resource.is_available_for(owner) or resource.resource_type() != 'mashup':
+                raise CatalogueResource.DoesNotExist
+        except CatalogueResource.DoesNotExist:
+            raise ValueError(_('Mashup not found: %(mashup)s') % {'mashup': mashup})
 
-        wgt = f if isinstance(f, WgtFile) else WgtFile(f)
+        base_dir = catalogue.wgt_deployer.get_base_dir(mashup_vendor, mashup_name, mashup_version)
+        wgt_file = WgtFile(os.path.join(base_dir, resource.template_uri))
+        template = TemplateParser(wgt_file.get_template())
+    elif isinstance(mashup, Workspace):
+        from wirecloud.platform.workspace.mashupTemplateGenerator import build_json_template_from_workspace
+        options = {
+            'vendor': 'api',
+            'name': mashup.name,
+            'version': '1.0',
+            'title': mashup.title if mashup.title is not None and mashup.title.strip() != "" else mashup.name,
+            'description': 'Temporal mashup for the workspace copy operation',
+            'email': 'a@example.com',
+        }
+
+        template = TemplateParser(build_json_template_from_workspace(options, mashup, mashup.creator))
+    else:
+        wgt = mashup if isinstance(mashup, WgtFile) else WgtFile(mashup)
         template = TemplateParser(wgt.get_template())
 
         resource_info = template.get_resource_processed_info(process_urls=False)
         if resource_info["type"] != 'mashup':
-            raise Exception
+            raise ValueError("WgtFile is not a mashup")
 
         for embedded_resource in resource_info['embedded']:
             if embedded_resource['src'].startswith('https://'):
@@ -578,24 +602,14 @@ def create_workspace(owner, f=None, mashup=None, new_name=None, new_title=None, 
 
             extra_resource_contents = WgtFile(resource_file)
             install_component(extra_resource_contents, executor_user=owner, users=[owner])
-    else:
-        values = mashup.split('/', 3)
-        if len(values) != 3:
-            raise TypeError(_('invalid mashup id'))
 
-        (mashup_vendor, mashup_name, mashup_version) = values
-        try:
-            resource = CatalogueResource.objects.get(vendor=mashup_vendor, short_name=mashup_name, version=mashup_version)
-            if not resource.is_available_for(owner) or resource.resource_type() != 'mashup':
-                raise CatalogueResource.DoesNotExist
-        except CatalogueResource.DoesNotExist:
-            raise Exception(_('Mashup not found: %(mashup)s') % {'mashup': mashup})
+    check_mashup_dependencies(template, owner)
 
-        base_dir = catalogue.wgt_deployer.get_base_dir(mashup_vendor, mashup_name, mashup_version)
-        wgt_file = WgtFile(os.path.join(base_dir, resource.template_uri))
-        template = TemplateParser(wgt_file.get_template())
+    if dry_run:
+        # TODO check name conflict
+        return None
 
-    workspace, _foo = buildWorkspaceFromTemplate(template, owner, new_name=new_name, new_title=new_title, searchable=searchable, public=public)
+    workspace, _foo = buildWorkspaceFromTemplate(template, owner, allow_renaming=allow_renaming, new_name=new_name, new_title=new_title, searchable=searchable, public=public)
 
     if len(preferences) > 0:
         update_workspace_preferences(workspace, preferences, invalidate_cache=False)


### PR DESCRIPTION
This PR updates WireCloud code to allow sharing dashboards with groups in addition to being able to share workspaces with users and organizations.