### PR TITLE
Update mkdocs configuration and dependencies

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -134,7 +134,7 @@ download them using the following URLs:
 -   [CoNWeT_simple-history-module2linear-graph_2.3.2.wgt](attachments/CoNWeT_simple-history-module2linear-graph_2.3.2.wgt)
 -   [CoNWeT_ngsi-source_3.0.7.wgt](attachments/CoNWeT_ngsi-source_3.0.7.wgt)
 -   [CoNWeT_ngsientity2poi_3.0.3.wgt](attachments/CoNWeT_ngsientity2poi_3.0.3.wgt)
--   [CoNWeT_map-viewer_2.5.8.wgt](attachments/CoNWeT_map-viewer_2.5.8.wgt)
+-   [CoNWeT_map-viewer_2.6.2.wgt](attachments/CoNWeT_map-viewer_2.6.2.wgt)
 -   [CoNWeT_linear-graph_3.0.0b3.wgt](attachments/CoNWeT_linear-graph_3.0.0b3.wgt)
 
 Once installed, you should be able to see all the widgets/operators used in this example in the _My Resources_ view:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,10 @@ pages:
         - 'Translations': 'development/platform/translation.md'
 - 'Appendix: Widgets': 'widgets.md'
 
+plugins:
+    - exclude:
+        glob:
+            - slides/*
 
 markdown_extensions:
     - markdown.extensions.tables

--- a/mkdocs_requirements.txt
+++ b/mkdocs_requirements.txt
@@ -1,1 +1,3 @@
+mkdocs==1.1
 pymdown-extensions
+mkdocs-exclude


### PR DESCRIPTION
Currently, RTD documentation is not building due the following exception:

```
Traceback (most recent call last):
  File "/home/docs/.pyenv/versions/3.7.3/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/docs/.pyenv/versions/3.7.3/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/wirecloud/envs/stable/lib/python3.7/site-packages/mkdocs/__main__.py", line 194, in <module>
    cli()
  File "/home/docs/checkouts/readthedocs.org/user_builds/wirecloud/envs/stable/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/docs/checkouts/readthedocs.org/user_builds/wirecloud/envs/stable/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/docs/checkouts/readthedocs.org/user_builds/wirecloud/envs/stable/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/docs/checkouts/readthedocs.org/user_builds/wirecloud/envs/stable/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/docs/checkouts/readthedocs.org/user_builds/wirecloud/envs/stable/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/docs/checkouts/readthedocs.org/user_builds/wirecloud/envs/stable/lib/python3.7/site-packages/mkdocs/__main__.py", line 156, in build_command
    ), dirty=not clean)
  File "/home/docs/checkouts/readthedocs.org/user_builds/wirecloud/envs/stable/lib/python3.7/site-packages/mkdocs/commands/build.py", line 282, in build
    build_pages(config, dirty=dirty)
  File "/home/docs/checkouts/readthedocs.org/user_builds/wirecloud/envs/stable/lib/python3.7/site-packages/mkdocs/commands/build.py", line 213, in build_pages
    site_navigation = nav.SiteNavigation(config)
  File "/home/docs/checkouts/readthedocs.org/user_builds/wirecloud/envs/stable/lib/python3.7/site-packages/mkdocs/nav.py", line 44, in __init__
    config, self.url_context)
  File "/home/docs/checkouts/readthedocs.org/user_builds/wirecloud/envs/stable/lib/python3.7/site-packages/mkdocs/nav.py", line 392, in _generate_site_navigation
    config_line, url_context, config):
  File "/home/docs/checkouts/readthedocs.org/user_builds/wirecloud/envs/stable/lib/python3.7/site-packages/mkdocs/nav.py", line 356, in _follow
    for sub in _follow(path, url_context, config, header=header, title=next_cat_or_title):
RuntimeError: generator raised StopIteration
```