### PR TITLE
Allow widgets to self-close

### DIFF
--- a/src/wirecloud/platform/static/js/WirecloudAPI/WirecloudWidgetAPI.js
+++ b/src/wirecloud/platform/static/js/WirecloudAPI/WirecloudWidgetAPI.js
@@ -1,5 +1,6 @@
 /*
  *     Copyright (c) 2012-2016 CoNWeT Lab., Universidad Politécnica de Madrid
+ *     Copyright (c) 2021 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -26,52 +27,65 @@
 
     "use strict";
 
-    var platform, view, model, IWidgetVariable, endpoint_name, inputs, outputs;
-
-    platform = window.parent;
-
     // Init resource entry (in this case a widget) so other API files can make
     // use of it
-    view = MashupPlatform.priv.workspaceview.findWidget(MashupPlatform.priv.id);
-    model = view.model;
+    const view = MashupPlatform.priv.workspaceview.findWidget(MashupPlatform.priv.id);
+    const model = view.model;
     MashupPlatform.priv.view = view;
     MashupPlatform.priv.resource = model;
 
-    IWidgetVariable = function IWidgetVariable(variable) {
-        this.set = function set(value) {
-            variable.set(value);
-        };
+    class IWidgetVariable {
 
-        this.get = function get() {
-            return variable.get();
-        };
-        Object.freeze(this);
-    };
+        constructor(variable) {
+            this.set = function set(value) {
+                variable.set(value);
+            };
+
+            this.get = function get() {
+                return variable.get();
+            };
+            Object.freeze(this);
+        }
+
+    }
 
     // Widget module
     Object.defineProperty(window.MashupPlatform, 'widget', {value: {}});
-    Object.defineProperty(window.MashupPlatform.widget, 'id', {value: MashupPlatform.priv.id});
-    Object.defineProperty(window.MashupPlatform.widget, 'getVariable', {
-        value: function getVariable(name) {
-            var variable = model.properties[name];
-            if (variable != null) {
-                return new IWidgetVariable(variable);
+    Object.defineProperties(window.MashupPlatform.widget, {
+        id: {
+            value: MashupPlatform.priv.id
+        },
+        getVariable: {
+            value: function getVariable(name) {
+                const variable = model.properties[name];
+                if (variable != null) {
+                    return new IWidgetVariable(variable);
+                }
+            }
+        },
+        drawAttention: {
+            value: function drawAttention() {
+                view.tab.workspace.drawAttention(model.id);
+            }
+        },
+        close: {
+            value: function close() {
+                if (!model.volatile) {
+                    throw new TypeError('Only volatile widgets can be closed');
+                }
+                model.remove();
+            }
+        },
+        context: {
+            value: {}
+        },
+        log: {
+            value: function log(msg, level) {
+                model.logManager.log(msg, level);
             }
         }
     });
 
-    Object.defineProperty(window.MashupPlatform.widget, 'drawAttention', {
-        value: function drawAttention() {
-            view.tab.workspace.drawAttention(model.id);
-        }
-    });
-
-    Object.defineProperty(window.MashupPlatform.widget, 'context', {value: {}});
-    Object.defineProperty(window.MashupPlatform.widget, 'log', {
-        value: function log(msg, level) {
-            model.logManager.log(msg, level);
-        }
-    });
     Object.defineProperty(window.MashupPlatform.widget.context, 'getAvailableContext', {
         value: function getAvailableContext() {
             return model.contextManager.getAvailableContext();
@@ -94,15 +108,15 @@
     Object.preventExtensions(window.MashupPlatform.widget.context);
 
     // Inputs
-    inputs = {};
-    for (endpoint_name in model.inputs) {
+    const inputs = {};
+    for (let endpoint_name in model.inputs) {
         inputs[endpoint_name] = new MashupPlatform.priv.InputEndpoint(model.inputs[endpoint_name], true);
     }
     Object.defineProperty(window.MashupPlatform.widget, 'inputs', {value: inputs});
 
     // Outputs
-    outputs = {};
-    for (endpoint_name in model.outputs) {
+    const outputs = {};
+    for (let endpoint_name in model.outputs) {
         outputs[endpoint_name] = new MashupPlatform.priv.OutputEndpoint(model.outputs[endpoint_name], true);
     }
     Object.defineProperty(window.MashupPlatform.widget, 'outputs', {value: outputs});

--- a/src/wirecloud/platform/static/js/wirecloud/Widget.js
+++ b/src/wirecloud/platform/static/js/wirecloud/Widget.js
@@ -280,45 +280,50 @@
             };
 
             this.contextManager = new Wirecloud.ContextManager(this, {
-                'title': {
+                title: {
                     label: utils.gettext("Title"),
                     description: utils.gettext("Widget's title"),
                     value: data.title
                 },
-                'xPosition': {
+                xPosition: {
                     label: utils.gettext("X-Position"),
                     description: utils.gettext("Specifies the x-coordinate at which the widget is placed"),
                     value: data.left
                 },
-                'yPosition': {
+                yPosition: {
                     label: utils.gettext("Y-Position"),
                     description: utils.gettext("Specifies the y-coordinate at which the widget is placed"),
                     value: data.top
                 },
-                'zPosition': {
+                zPosition: {
                     label: utils.gettext("Z-Position"),
                     description: utils.gettext("Specifies the z-coordinate at which the widget is placed"),
                     value: data.zIndex
                 },
-                'height': {
+                height: {
                     label: utils.gettext("Height"),
                     description: utils.gettext("Widget's height in layout cells"),
                     value: data.height
                 },
-                'width': {
+                width: {
                     label: utils.gettext("Width"),
                     description: utils.gettext("Widget's width in layout cells"),
                     value: data.width
                 },
-                'heightInPixels': {
+                heightInPixels: {
                     label: utils.gettext("Height in pixels (deprecated)"),
                     description: utils.gettext("Widget's height in pixels"),
                     value: 0
                 },
-                'widthInPixels': {
+                widthInPixels: {
                     label: utils.gettext("Width in pixels"),
                     description: utils.gettext("Widget's width in pixels"),
                     value: 0
+                },
+                volatile: {
+                    label: utils.gettext("Volatile"),
+                    description: utils.gettext("Volatile status of the widget"),
+                    value: this.volatile
                 }
             });
 


### PR DESCRIPTION
## Proposed changes

Allow volatile widgets to self close. This is done by adding a `close` method on the `MashupPlatform.widget` API. This PR also adds support for knowing if the widget is running in volatile mode (required to be able to call the `close` method)

## Types of changes

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/Wirecloud/wirecloud/blob/develop/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules