### PR TITLE
Initial support for a bottom version of the SidebarLayout

### DIFF
--- a/src/js_tests/wirecloud/ui/SidebarLayoutSpec.js
+++ b/src/js_tests/wirecloud/ui/SidebarLayoutSpec.js
@@ -1,5 +1,5 @@
 /*
- *     Copyright (c) 2019 Future Internet Consulting and Development Solutions S.L.
+ *     Copyright (c) 2019-2020 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -29,6 +29,12 @@
     describe("SidebarLayout", () => {
 
         describe("new SidebarLayout(dragboard[, options])", () => {
+
+            it("is a class constructor", () => {
+                expect(() => {
+                    ns.SidebarLayout({});  // eslint-disable-line new-cap
+                }).toThrowError(TypeError);
+            });
 
             it("should work without providing options", () => {
                 var dragboard = {};

--- a/src/js_tests/wirecloud/ui/SidebarLayoutSpec.js
+++ b/src/js_tests/wirecloud/ui/SidebarLayoutSpec.js
@@ -1,5 +1,5 @@
 /*
- *     Copyright (c) 2019-2020 Future Internet Consulting and Development Solutions S.L.
+ *     Copyright (c) 2019-2021 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -43,6 +43,12 @@
                 // Check initial values
                 expect(layout.active).toBe(false);
                 expect(layout.position).toBe("left");
+            });
+
+            it("should validate the position option", () => {
+                expect(() => {
+                    new ns.SidebarLayout({}, {position: "invalid"});
+                }).toThrowError(TypeError);
             });
 
             it("should allow to provide a custom position", () => {
@@ -109,10 +115,41 @@
 
         describe("adaptColumnOffset(value)", () => {
 
-            it("should always return 0 cell size", () => {
-                let layout = new ns.SidebarLayout({});
+            it("should call parent method for top sidebars", () => {
+                const result = {};
+                spyOn(Wirecloud.ui.SmartColumnLayout.prototype, "adaptColumnOffset").and.returnValue(result);
+                const layout = new ns.SidebarLayout({}, {position: "top"});
 
-                let value = layout.adaptColumnOffset(50);
+                const value = layout.adaptColumnOffset(50);
+
+                expect(Wirecloud.ui.SmartColumnLayout.prototype.adaptColumnOffset).toHaveBeenCalledWith(50);
+                expect(value).toBe(result);
+            });
+
+            it("should call parent method for bottom sidebars", () => {
+                const result = {};
+                spyOn(Wirecloud.ui.SmartColumnLayout.prototype, "adaptColumnOffset").and.returnValue(result);
+                const layout = new ns.SidebarLayout({}, {position: "bottom"});
+
+                const value = layout.adaptColumnOffset(50);
+
+                expect(Wirecloud.ui.SmartColumnLayout.prototype.adaptColumnOffset).toHaveBeenCalledWith(50);
+                expect(value).toBe(result);
+            });
+
+            it("should always return 0 cell size for left sidebars", () => {
+                const layout = new ns.SidebarLayout({}, {position: "left"});
+
+                const value = layout.adaptColumnOffset(50);
+
+                expect(value.inLU).toBe(0);
+                expect(value.inPixels).toBe(0);
+            });
+
+            it("should always return 0 cell size for right sidebars", () => {
+                const layout = new ns.SidebarLayout({}, {position: "right"});
+
+                const value = layout.adaptColumnOffset(50);
 
                 expect(value.inLU).toBe(0);
                 expect(value.inPixels).toBe(0);
@@ -120,12 +157,131 @@
 
         });
 
+        describe("adaptRowOffset(value)", () => {
+
+            it("should call parent method for left sidebars", () => {
+                const result = {};
+                spyOn(Wirecloud.ui.SmartColumnLayout.prototype, "adaptRowOffset").and.returnValue(result);
+                const layout = new ns.SidebarLayout({}, {position: "left"});
+
+                const value = layout.adaptRowOffset(50);
+
+                expect(Wirecloud.ui.SmartColumnLayout.prototype.adaptRowOffset).toHaveBeenCalledWith(50);
+                expect(value).toBe(result);
+            });
+
+            it("should call parent method for right sidebars", () => {
+                const result = {};
+                spyOn(Wirecloud.ui.SmartColumnLayout.prototype, "adaptRowOffset").and.returnValue(result);
+                const layout = new ns.SidebarLayout({}, {position: "right"});
+
+                const value = layout.adaptRowOffset(50);
+
+                expect(Wirecloud.ui.SmartColumnLayout.prototype.adaptRowOffset).toHaveBeenCalledWith(50);
+                expect(value).toBe(result);
+            });
+
+            it("should always return 0 cell size for top sidebars", () => {
+                const layout = new ns.SidebarLayout({}, {position: "top"});
+
+                const value = layout.adaptRowOffset(50);
+
+                expect(value.inLU).toBe(0);
+                expect(value.inPixels).toBe(0);
+            });
+
+            it("should always return 0 cell size for bottom sidebars", () => {
+                const layout = new ns.SidebarLayout({}, {position: "bottom"});
+
+                const value = layout.adaptRowOffset(50);
+
+                expect(value.inLU).toBe(0);
+                expect(value.inPixels).toBe(0);
+            });
+
+        });
+
+        describe("adaptHeight(size)", () => {
+
+            it("should call parent method for left sidebars", () => {
+                const result = {};
+                spyOn(Wirecloud.ui.SmartColumnLayout.prototype, "adaptHeight").and.returnValue(result);
+                const layout = new ns.SidebarLayout({}, {position: "left"});
+
+                const value = layout.adaptHeight(50);
+
+                expect(Wirecloud.ui.SmartColumnLayout.prototype.adaptHeight).toHaveBeenCalledWith(50);
+                expect(value).toBe(result);
+            });
+
+            it("should call parent method for right sidebars", () => {
+                const result = {};
+                spyOn(Wirecloud.ui.SmartColumnLayout.prototype, "adaptHeight").and.returnValue(result);
+                const layout = new ns.SidebarLayout({}, {position: "right"});
+
+                const value = layout.adaptHeight(50);
+
+                expect(Wirecloud.ui.SmartColumnLayout.prototype.adaptHeight).toHaveBeenCalledWith(50);
+                expect(value).toBe(result);
+            });
+
+            it("should always return 1 cell size for top sidebars", () => {
+                const layout = new ns.SidebarLayout({}, {position: "top"});
+
+                const value = layout.adaptHeight(50);
+
+                expect(value.inLU).toBe(1);
+                expect(value.inPixels).toBe(layout.getHeight());
+            });
+
+            it("should always return 1 cell size for bottom sidebars", () => {
+                const layout = new ns.SidebarLayout({}, {position: "bottom"});
+
+                const value = layout.adaptHeight(50);
+
+                expect(value.inLU).toBe(1);
+                expect(value.inPixels).toBe(layout.getHeight());
+            });
+
+        });
+
         describe("adaptWidth(size)", () => {
 
-            it("should always return 1 cell size", () => {
-                let layout = new ns.SidebarLayout({});
+            it("should call parent method for top sidebars", () => {
+                const result = {};
+                spyOn(Wirecloud.ui.SmartColumnLayout.prototype, "adaptWidth").and.returnValue(result);
+                const layout = new ns.SidebarLayout({}, {position: "top"});
 
-                let value = layout.adaptWidth(50);
+                const value = layout.adaptWidth(50);
+
+                expect(Wirecloud.ui.SmartColumnLayout.prototype.adaptWidth).toHaveBeenCalledWith(50);
+                expect(value).toBe(result);
+            });
+
+            it("should call parent method for bottom sidebars", () => {
+                const result = {};
+                spyOn(Wirecloud.ui.SmartColumnLayout.prototype, "adaptWidth").and.returnValue(result);
+                const layout = new ns.SidebarLayout({}, {position: "bottom"});
+
+                const value = layout.adaptWidth(50);
+
+                expect(Wirecloud.ui.SmartColumnLayout.prototype.adaptWidth).toHaveBeenCalledWith(50);
+                expect(value).toBe(result);
+            });
+
+            it("should always return 1 cell size for left sidebars", () => {
+                const layout = new ns.SidebarLayout({}, {position: "left"});
+
+                const value = layout.adaptWidth(50);
+
+                expect(value.inLU).toBe(1);
+                expect(value.inPixels).toBe(layout.getWidth());
+            });
+
+            it("should always return 1 cell size for right sidebars", () => {
+                const layout = new ns.SidebarLayout({}, {position: "left"});
+
+                const value = layout.adaptWidth(50);
 
                 expect(value.inLU).toBe(1);
                 expect(value.inPixels).toBe(layout.getWidth());
@@ -179,6 +335,92 @@
 
         });
 
+        describe("getHeight()", () => {
+
+            it("should call parent method for left sidebars", () => {
+                const result = 600;
+                spyOn(Wirecloud.ui.SmartColumnLayout.prototype, "getHeight").and.returnValue(result);
+                const layout = new ns.SidebarLayout({}, {position: "left"});
+
+                const value = layout.getHeight();
+
+                expect(Wirecloud.ui.SmartColumnLayout.prototype.getHeight).toHaveBeenCalledWith();
+                expect(value).toBe(result);
+            });
+
+            it("should call parent method for right sidebars", () => {
+                const result = 600;
+                spyOn(Wirecloud.ui.SmartColumnLayout.prototype, "getHeight").and.returnValue(result);
+                const layout = new ns.SidebarLayout({}, {position: "right"});
+
+                const value = layout.getHeight();
+
+                expect(Wirecloud.ui.SmartColumnLayout.prototype.getHeight).toHaveBeenCalledWith();
+                expect(value).toBe(result);
+            });
+
+            it("should always return 1 cell size for top sidebars", () => {
+                spyOn(Wirecloud.ui.SmartColumnLayout.prototype, "getHeight");
+                const layout = new ns.SidebarLayout({}, {position: "top"});
+
+                const value = layout.getHeight();
+
+                expect(value).toEqual(jasmine.any(Number));
+            });
+
+            it("should always return 1 cell size for bottom sidebars", () => {
+                spyOn(Wirecloud.ui.SmartColumnLayout.prototype, "getHeight");
+                const layout = new ns.SidebarLayout({}, {position: "bottom"});
+
+                const value = layout.getHeight(2);
+
+                expect(value).toEqual(jasmine.any(Number));
+            });
+
+        });
+
+        describe("getHeightInPixels(size)", () => {
+
+            it("should call parent method for left sidebars", () => {
+                const result = {};
+                spyOn(Wirecloud.ui.SmartColumnLayout.prototype, "getHeightInPixels").and.returnValue(result);
+                const layout = new ns.SidebarLayout({}, {position: "left"});
+
+                const value = layout.getHeightInPixels(2);
+
+                expect(Wirecloud.ui.SmartColumnLayout.prototype.getHeightInPixels).toHaveBeenCalledWith(2);
+                expect(value).toBe(result);
+            });
+
+            it("should call parent method for right sidebars", () => {
+                const result = {};
+                spyOn(Wirecloud.ui.SmartColumnLayout.prototype, "getHeightInPixels").and.returnValue(result);
+                const layout = new ns.SidebarLayout({}, {position: "right"});
+
+                const value = layout.getHeightInPixels(2);
+
+                expect(Wirecloud.ui.SmartColumnLayout.prototype.getHeightInPixels).toHaveBeenCalledWith(2);
+                expect(value).toBe(result);
+            });
+
+            it("should always return 1 cell size for top sidebars", () => {
+                const layout = new ns.SidebarLayout({}, {position: "top"});
+
+                const value = layout.getHeightInPixels(2);
+
+                expect(value).toBe(layout.getHeight());
+            });
+
+            it("should always return 1 cell size for bottom sidebars", () => {
+                const layout = new ns.SidebarLayout({}, {position: "bottom"});
+
+                const value = layout.getHeightInPixels(2);
+
+                expect(value).toBe(layout.getHeight());
+            });
+
+        });
+
         describe("initialize()", () => {
 
             it("should work on empty layouts", () => {
@@ -188,7 +430,7 @@
                 layout.initialize();
             });
 
-            it("should enable layout handle if there are widget", () => {
+            it("should enable layout handle if there is a widget in the first position", () => {
                 spyOn(Wirecloud.ui.SmartColumnLayout.prototype, "initialize");
                 let layout = new ns.SidebarLayout({});
                 let widget = {
@@ -196,6 +438,17 @@
                 };
 
                 layout.matrix[0][0] = widget;
+                layout.initialize();
+            });
+
+            it("should enable layout handle if there is a widget", () => {
+                spyOn(Wirecloud.ui.SmartColumnLayout.prototype, "initialize");
+                let layout = new ns.SidebarLayout({}, {position: "top"});
+                let widget = {
+                    wrapperElement: document.createElement('div')
+                };
+
+                layout.matrix[4][0] = widget;
                 layout.initialize();
             });
 
@@ -239,7 +492,9 @@
                     tab: {
                         workspace: {
                         }
-                    }
+                    },
+                    getWidth: jasmine.createSpy("getWidth").and.returnValue(800),
+                    getHeight: jasmine.createSpy("getHeight").and.returnValue(600)
                 };
                 element = document.createElement('div');
             });
@@ -300,6 +555,68 @@
                 expect(element.style.top).toBe("2px");
                 expect(element.style.left).toBe("");
                 expect(element.style.right).toBe("0px");
+            });
+
+            it("should work on top position (inactive)", () => {
+                layout = new ns.SidebarLayout(dragboard, {position: "top"});
+                let widget = {
+                    position: {
+                        y: 0
+                    }
+                };
+                layout.updatePosition(widget, element);
+
+                expect(element.style.bottom).toBe("");
+                expect(element.style.top).toBe("-498px");
+                expect(element.style.left).toBe("");
+                expect(element.style.right).toBe("");
+            });
+
+            it("should work on top position (active)", () => {
+                layout = new ns.SidebarLayout(dragboard, {position: "top"});
+                let widget = {
+                    position: {
+                        y: 0
+                    }
+                };
+                layout.active = true;
+                layout.updatePosition(widget, element);
+
+                expect(element.style.bottom).toBe("");
+                expect(element.style.top).toBe("0px");
+                expect(element.style.left).toBe("");
+                expect(element.style.right).toBe("");
+            });
+
+            it("should work on bottom position (inactive)", () => {
+                layout = new ns.SidebarLayout(dragboard, {position: "bottom"});
+                let widget = {
+                    position: {
+                        y: 0
+                    }
+                };
+                layout.updatePosition(widget, element);
+
+                expect(element.style.bottom).toBe("-498px");
+                expect(element.style.top).toBe("");
+                expect(element.style.left).toBe("");
+                expect(element.style.right).toBe("");
+            });
+
+            it("should work on bottom position (active)", () => {
+                layout = new ns.SidebarLayout(dragboard, {position: "bottom"});
+                let widget = {
+                    position: {
+                        y: 0
+                    }
+                };
+                layout.active = true;
+                layout.updatePosition(widget, element);
+
+                expect(element.style.bottom).toBe("0px");
+                expect(element.style.top).toBe("");
+                expect(element.style.left).toBe("");
+                expect(element.style.right).toBe("");
             });
 
         });

--- a/src/js_tests/wirecloud/ui/WidgetViewSpec.js
+++ b/src/js_tests/wirecloud/ui/WidgetViewSpec.js
@@ -77,7 +77,9 @@
                     widget.layout = null;
                     return new Set();
                 }),
+                getHeight: jasmine.createSpy("getHeight"),
                 getHeightInPixels: jasmine.createSpy("getHeightInPixels"),
+                getWidth: jasmine.createSpy("getWidth"),
                 _notifyResizeEvent: jasmine.createSpy("_notifyResizeEvent")
             });
             if ("_searchFreeSpace" in klass.prototype) {

--- a/src/js_tests/wirecloud/ui/WorkspaceViewSpec.js
+++ b/src/js_tests/wirecloud/ui/WorkspaceViewSpec.js
@@ -120,6 +120,12 @@
                         },
                         rightLayout: {
                             active: false
+                        },
+                        bottomLayout: {
+                            active: false
+                        },
+                        topLayout: {
+                            active: false
                         }
                     };
                 }

--- a/src/wirecloud/defaulttheme/static/css/workspace/dragboard.scss
+++ b/src/wirecloud/defaulttheme/static/css/workspace/dragboard.scss
@@ -69,3 +69,47 @@
     padding-left: 8px;
     padding-right: 10px;
 }
+
+.wc-sidebar-bottom-handle {
+    position: absolute;
+    color: $button-text-color-light;
+    bottom: 495px;
+    left: 50%;
+    transform: translate(-50%, 0);
+    background: rgb(255, 255, 255);
+    padding: 1px 20px 0px 20px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    border-width: 1px 1px 0px 1px;
+    border-style: solid;
+    border-color: $button-border-default;
+    cursor: pointer;
+}
+
+.wc-sidebar-bottom-handle:hover {
+    background-color: darken(white, 10%);
+    padding-top: 3px;
+    padding-bottom: 2px;
+}
+
+.wc-sidebar-top-handle {
+    position: absolute;
+    color: $button-text-color-light;
+    top: 495px;
+    left: 50%;
+    transform: translate(-50%, 0);
+    background: rgb(255, 255, 255);
+    padding: 0px 20px 1px 20px;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-width: 0px 1px 1px 1px;
+    border-style: solid;
+    border-color: $button-border-default;
+    cursor: pointer;
+}
+
+.wc-sidebar-top-handle:hover {
+    background-color: darken(white, 10%);
+    padding-top: 2px;
+    padding-bottom: 3px;
+}

--- a/src/wirecloud/platform/static/js/wirecloud/ui/ColumnLayout.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/ColumnLayout.js
@@ -143,7 +143,7 @@
         }
 
         adaptRowOffset(size) {
-            var offsetInLU, pixels, parsedSize;
+            let offsetInLU, pixels, parsedSize;
 
             parsedSize = this.parseSize(size);
             if (parsedSize[1] === 'cells') {
@@ -167,14 +167,15 @@
             return height + this.topMargin + this.bottomMargin;
         }
 
-        getColumnOffset(position) {
-            var tmp = Math.floor((this.getWidth() * this.fromHCellsToPercentage(position.x)) / 100);
+        getColumnOffset(position, css) {
+            let tmp = Math.floor((this.getWidth() * this.fromHCellsToPercentage(position.x)) / 100);
             tmp += this.leftMargin + this.dragboard.leftMargin;
-            return tmp;
+            return css ? tmp + 'px' : tmp;
         }
 
-        getRowOffset(position) {
-            return this.dragboard.topMargin + this.fromVCellsToPixels(position.y) + this.topMargin;
+        getRowOffset(position, css) {
+            let offset = this.dragboard.topMargin + this.fromVCellsToPixels(position.y) + this.topMargin;
+            return css ? offset + 'px' : offset;
         }
 
         _notifyWindowResizeEvent(widthChanged, heightChanged) {
@@ -203,16 +204,14 @@
             this.matrix = [];
             this._buffers.base.matrix = this.matrix;
 
-            for (var x = 0; x < this.columns; x++) {
+            for (let x = 0; x < this.columns; x++) {
                 this.matrix[x] = [];
             }
         }
 
         _hasSpaceFor(_matrix, positionX, positionY, width, height) {
-            var x, y;
-
-            for (x = 0; x < width; x++) {
-                for (y = 0; y < height; y++) {
+            for (let x = 0; x < width; x++) {
+                for (let y = 0; y < height; y++) {
                     if (_matrix[positionX + x][positionY + y] != null) {
                         return false;
                     }
@@ -232,10 +231,8 @@
         }
 
         _compressColumns(_matrix, x, width) {
-            var i, y;
-
-            for (i = 0; i < width; i++) {
-                for (y = _matrix[x + i].length - 1; y >= 0; y--) {
+            for (let i = 0; i < width; i++) {
+                for (let y = _matrix[x + i].length - 1; y >= 0; y--) {
                     if (_matrix[x + i][y] != null) {
                         break;
                     }
@@ -338,28 +335,24 @@
         }
 
         _reserveSpace(buffer, widget) {
-            var position = this._getPositionOn(buffer, widget);
-            var width = widget.shape.width;
-            var height = widget.shape.height;
+            const position = this._getPositionOn(buffer, widget);
+            const width = widget.shape.width;
+            const height = widget.shape.height;
 
             this._reserveSpace2(buffer.matrix, widget, position.x, position.y, width, height);
         }
 
         _reserveSpace2(matrix, widget, positionX, positionY, width, height) {
-            var x, y;
-
-            for (x = 0; x < width; x++) {
-                for (y = 0; y < height; y++) {
+            for (let x = 0; x < width; x++) {
+                for (let y = 0; y < height; y++) {
                     matrix[positionX + x][positionY + y] = widget;
                 }
             }
         }
 
         _clearSpace2(_matrix, positionX, positionY, width, height) {
-            var x, y;
-
-            for (x = 0; x < width; x++) {
-                for (y = 0; y < height; y++) {
+            for (let x = 0; x < width; x++) {
+                for (let y = 0; y < height; y++) {
                     delete _matrix[positionX + x][positionY + y];
                 }
             }

--- a/src/wirecloud/platform/static/js/wirecloud/ui/SidebarLayout.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/SidebarLayout.js
@@ -28,10 +28,19 @@
 
     const privates = new WeakMap();
 
-    const OPPOSITE = {
+    const ICON = Object.freeze({
+        "right": "right",
+        "left": "left",
+        "top": "up",
+        "bottom": "down"
+    });
+    const OPPOSITE = Object.freeze({
         "right": "left",
-        "left": "right"
-    };
+        "left": "right",
+        "bottom": "up",
+        "top": "down"
+    });
+    const POSITIONS = Object.freeze(["top", "right", "bottom", "left"]);
 
     const on_active_get = function on_active_get() {
         return privates.get(this).active;
@@ -48,8 +57,8 @@
 
         privates.get(this).active = newstatus;
 
-        let position = this.active ? this.position : OPPOSITE[this.position];
-        this.handleicon.className = "fas fa-caret-" + position;
+        let icon = this.active ? ICON[this.position] : OPPOSITE[this.position];
+        this.handleicon.className = "fas fa-caret-" + icon;
 
         this._notifyWindowResizeEvent(true, true);
     };
@@ -69,6 +78,10 @@
                 3,
                 12
             );
+
+            if (POSITIONS.indexOf(options.position) === -1) {
+                throw new TypeError("Invalid position option: " + options.position);
+            }
 
             privates.set(this, {
                 active: false
@@ -127,8 +140,12 @@
             return new Wirecloud.ui.MultiValuedSize(this.getWidth(), 1);
         }
 
+        getHeight() {
+            return this.position === "top" || this.position === "bottom" ? 497 : super.getHeight();
+        }
+
         getWidth() {
-            return 497;
+            return this.position === "left" || this.position === "right" ? 497 : super.getWidth();
         }
 
         initialize() {
@@ -140,21 +157,46 @@
         }
 
         updatePosition(widget, element) {
-            var offset;
-            if (!this.active) {
-                offset = -this.getWidth() - this.leftMargin + this.dragboard.leftMargin;
-            } else {
-                offset = 0;
-            }
-
-            element.style.top = this.getRowOffset(widget.position) + "px";
-            element.style.bottom = "";
-            if (this.position === "left") {
-                element.style.left = offset + "px";
+            if (this.position === "top" || this.position === "bottom") {
+                let offset;
+                if (!this.active) {
+                    offset = -this.getHeight();
+                } else {
+                    offset = 0;
+                }
+                element.style.left = this.getColumnOffset(widget.position, true);
                 element.style.right = "";
+                if (this.position === "top") {
+                    element.style.top = offset + "px";
+                    element.style.bottom = "";
+                } else {
+                    element.style.bottom = offset + "px";
+                    element.style.top = "";
+                }
+            } else /* if (this.position === "left" || this.position === "right") */ {
+                let offset;
+                if (!this.active) {
+                    offset = -this.getWidth() - this.leftMargin + this.dragboard.leftMargin;
+                } else {
+                    offset = 0;
+                }
+                element.style.top = this.getRowOffset(widget.position, true);
+                element.style.bottom = "";
+                if (this.position === "left") {
+                    element.style.left = offset + "px";
+                    element.style.right = "";
+                } else {
+                    element.style.right = offset + "px";
+                    element.style.left = "";
+                }
+            }
+        }
+
+        getHeightInPixels(cells) {
+            if (this.position === "top" || this.position === "bottom") {
+                return this.getHeight();
             } else {
-                element.style.right = offset + "px";
-                element.style.left = "";
+                return super.getHeightInPixels(cells);
             }
         }
 

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WidgetViewMenuItems.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WidgetViewMenuItems.js
@@ -263,11 +263,11 @@
                 items.push(item);
             }
 
-            if (this.widget.layout !== this.widget.tab.dragboard.leftLayout) {
-                item = new se.MenuItem(utils.gettext("Move to the left sidebar"), () => {
-                    this.widget.moveToLayout(this.widget.tab.dragboard.leftLayout);
+            if (this.widget.layout !== this.widget.tab.dragboard.topLayout) {
+                item = new se.MenuItem(utils.gettext("Move to the top sidebar"), () => {
+                    this.widget.moveToLayout(this.widget.tab.dragboard.topLayout);
                 });
-                item.addIconClass("fas fa-caret-square-left")
+                item.addIconClass("fas fa-caret-square-up")
                     .setDisabled(!this.widget.model.isAllowed('move', 'editor'));
                 items.push(item);
             }
@@ -277,6 +277,24 @@
                     this.widget.moveToLayout(this.widget.tab.dragboard.rightLayout);
                 });
                 item.addIconClass("fas fa-caret-square-right")
+                    .setDisabled(!this.widget.model.isAllowed('move', 'editor'));
+                items.push(item);
+            }
+
+            if (this.widget.layout !== this.widget.tab.dragboard.bottomLayout) {
+                item = new se.MenuItem(utils.gettext("Move to the bottom sidebar"), () => {
+                    this.widget.moveToLayout(this.widget.tab.dragboard.bottomLayout);
+                });
+                item.addIconClass("fas fa-caret-square-down")
+                    .setDisabled(!this.widget.model.isAllowed('move', 'editor'));
+                items.push(item);
+            }
+
+            if (this.widget.layout !== this.widget.tab.dragboard.leftLayout) {
+                item = new se.MenuItem(utils.gettext("Move to the left sidebar"), () => {
+                    this.widget.moveToLayout(this.widget.tab.dragboard.leftLayout);
+                });
+                item.addIconClass("fas fa-caret-square-left")
                     .setDisabled(!this.widget.model.isAllowed('move', 'editor'));
                 items.push(item);
             }

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WorkspaceView.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WorkspaceView.js
@@ -56,8 +56,10 @@
             });
             this.editButton.addEventListener("active", (button) => {
                 if (this.editing) {
-                    this.activeTab.dragboard.leftLayout.active = true;
+                    this.activeTab.dragboard.topLayout.active = true;
                     this.activeTab.dragboard.rightLayout.active = true;
+                    this.activeTab.dragboard.bottomLayout.active = true;
+                    this.activeTab.dragboard.leftLayout.active = true;
                 }
                 if (this.model != null) {
                     this.model.contextManager.modify({editing: this.editing});


### PR DESCRIPTION
## Proposed changes

This PR adds sidebar layouts for the top and bottom sides in addition to the currently supported left and right sidebars.

## Types of changes

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/Wirecloud/wirecloud/blob/develop/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

This PR also moves the `WorkspaceTabViewDragboard` class to use the ES6 syntax.

