### PR TITLE
Allow setting multiple prefs at the same time using MashupPlatform.prefs.set

### DIFF
--- a/src/js_tests/wirecloud/UserPrefDefSpec.js
+++ b/src/js_tests/wirecloud/UserPrefDefSpec.js
@@ -61,7 +61,8 @@
                     type: "text",
                     label: "label content",
                     description: "pref description",
-                    required: true
+                    required: true,
+                    secure: false
                 });
 
                 expect(meta.name).toBe("pref");
@@ -69,7 +70,7 @@
                 expect(meta.label).toBe("label content");
                 expect(meta.description).toBe("pref description");
                 expect(meta.required).toBe(true);
-
+                expect(meta.secure).toBe(false);
             });
 
             describe("boolean", () => {

--- a/src/wirecloud/platform/static/js/wirecloud/UserPrefDef.js
+++ b/src/wirecloud/platform/static/js/wirecloud/UserPrefDef.js
@@ -1,5 +1,6 @@
 /*
  *     Copyright (c) 2012-2017 CoNWeT Lab., Universidad Politécnica de Madrid
+ *     Copyright (c) 2021 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -49,6 +50,7 @@
             label: {value: options.label},
             description: {value: options.description},
             required: {value: options.required},
+            secure: {value: options.secure},
             options: {value: options.options}
         });
 

--- a/src/wirecloud/platform/static/js/wirecloud/Widget.js
+++ b/src/wirecloud/platform/static/js/wirecloud/Widget.js
@@ -864,7 +864,7 @@
                 }
             }
 
-            if (!this.volatile) {
+            if (!this.volatile && Object.keys(newValues).length > 0) {
                 return Wirecloud.io.makeRequest(Wirecloud.URLs.IWIDGET_PREFERENCES.evaluate({
                     workspace_id: this.tab.workspace.id,
                     tab_id: this.tab.id,

--- a/src/wirecloud/platform/static/js/wirecloud/Widget.js
+++ b/src/wirecloud/platform/static/js/wirecloud/Widget.js
@@ -1,6 +1,6 @@
 /*
  *     Copyright (c) 2013-2017 CoNWeT Lab., Universidad Politécnica de Madrid
- *     Copyright (c) 2019-2020 Future Internet Consulting and Development Solutions S.L.
+ *     Copyright (c) 2019-2021 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -205,6 +205,15 @@
     const send_pending_event = function send_pending_event(pendingEvent) {
         this.inputs[pendingEvent.endpoint].propagate(pendingEvent.value);
     };
+
+    const censor_secure_preferences = function censor_secure_preferences(newValues) {
+        // Censor secure preferences
+        for (const varName in newValues) {
+            if (this.preferences[varName].meta.secure) {
+                newValues[varName] = "********";
+            }
+        }
+    }
 
     // =========================================================================
     // EVENT HANDLERS
@@ -829,6 +838,62 @@
         setPosition(position) {
             utils.update(privates.get(this).position, position);
             return this;
+        }
+
+        setPreferences(newValues) {
+            // We are going to modify the object, let's create a copy
+            newValues = Object.assign({}, newValues);
+
+            for (const prefName in newValues) {
+                if (!(prefName in this.preferences)) {
+                    delete newValues[prefName];
+                    continue;
+                }
+
+                const oldValue = this.preferences[prefName].value;
+                const newValue = newValues[prefName];
+
+                if (newValue !== oldValue) {
+                    if (this.preferences[prefName].meta.secure && newValue !== "") {
+                        this.preferences[prefName].value = "********";
+                    } else {
+                        this.preferences[prefName].value = newValue;
+                    }
+                } else {
+                    delete newValues[prefName];
+                }
+            }
+
+            if (!this.volatile) {
+                return Wirecloud.io.makeRequest(Wirecloud.URLs.IWIDGET_PREFERENCES.evaluate({
+                    workspace_id: this.tab.workspace.id,
+                    tab_id: this.tab.id,
+                    iwidget_id: this.id
+                }), {
+                    method: 'POST',
+                    contentType: 'application/json',
+                    requestHeaders: {'Accept': 'application/json'},
+                    postBody: JSON.stringify(newValues)
+                }).then((response) => {
+                    if (response.status !== 204) {
+                        return Promise.reject(new Error("Unexpected response from server"));
+                    }
+
+                    censor_secure_preferences.call(this, newValues);
+
+                    try {
+                        this.prefCallback(newValues);
+                    } catch (error) {
+                        const details = this.logManager.formatException(error);
+                        this.logManager.log(utils.gettext('Exception catched while processing preference changes'), {details: details});
+                    }
+
+                    return newValues;
+                });
+            } else {
+                censor_secure_preferences.call(this, newValues);
+                return Promise.resolve(newValues);
+            }
         }
 
         setShape(shape) {


### PR DESCRIPTION
## Proposed changes

This PR makes `MashupPlatform.prefs.set` allow to pass an object with changes on multiple preferences.

## Types of changes

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/Wirecloud/wirecloud/blob/develop/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The idea is to reduce the number of calls to the API used to persist the new values.