### PR TITLE
Refactor StyledElements Widget API to work with es6 classes

### DIFF
--- a/src/js_tests/styledelements/EventSpec.js
+++ b/src/js_tests/styledelements/EventSpec.js
@@ -66,7 +66,8 @@
             });
 
             it("should work on events with listeners (dispatching)", () => {
-                const event = new se.Event({});
+                const context = {};
+                const event = new se.Event(context);
                 const listener1 = jasmine.createSpy("listener1").and.callFake(() => {
                     event.clearEventListeners();
                 });
@@ -76,7 +77,7 @@
 
                 event.dispatch();
 
-                expect(listener1).toHaveBeenCalledWith();
+                expect(listener1).toHaveBeenCalledWith(context);
                 expect(listener2).not.toHaveBeenCalled();
                 expect(event.handlers).toEqual([]);
             });

--- a/src/js_tests/styledelements/ObjectWithEventsSpec.js
+++ b/src/js_tests/styledelements/ObjectWithEventsSpec.js
@@ -1,5 +1,6 @@
 /*
  *     Copyright (c) 2016 CoNWeT Lab., Universidad Politécnica de Madrid
+ *     Copyright (c) 2021 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -26,38 +27,44 @@
 
     "use strict";
 
-    describe("Styled ObjectWithEvents", function () {
+    describe("Styled ObjectWithEvents", () => {
 
-        describe("new ObjectWithEvents([eventTypes])", function () {
+        describe("new ObjectWithEvents([eventTypes])", () => {
 
-            it("should create an instance given an eventType list", function () {
+            it("eventTypes is not required", () => {
+                const eventTarget = new StyledElements.ObjectWithEvents();
+                expect(Object.keys(eventTarget.events)).toEqual([]);
+            });
+
+            it("should create an instance given an eventType list", () => {
                 const eventTarget = new StyledElements.ObjectWithEvents(['click']);
                 expect(Object.keys(eventTarget.events)).toEqual(['click']);
             });
+
         });
 
-        describe("addEventListener(eventType, eventListener)", function () {
+        describe("addEventListener(eventType, eventListener)", () => {
 
-            it("should throw error if the eventType does not exist", function () {
+            it("should throw error if the eventType does not exist", () => {
                 const eventTarget = new StyledElements.ObjectWithEvents(['click']);
-                const eventListener = function (element) {};
+                const eventListener = (element) => {};
 
-                expect(function () {
+                expect(() => {
                     eventTarget.addEventListener('focus', eventListener);
                 }).toThrow(jasmine.any(Error));
             });
 
-            it("should throw error if the eventListener is not a function", function () {
+            it("should throw error if the eventListener is not a function", () => {
                 const eventTarget = new StyledElements.ObjectWithEvents(['click']);
 
-                expect(function () {
+                expect(() => {
                     eventTarget.addEventListener('click', null);
                 }).toThrow(jasmine.any(TypeError));
             });
 
-            it("should add more than once the same eventListener", function () {
+            it("should add more than once the same eventListener", () => {
                 const eventTarget = new StyledElements.ObjectWithEvents(['click']);
-                const eventListener = function (element) {};
+                const eventListener = (element) => {};
 
                 eventTarget.addEventListener('click', eventListener);
                 eventTarget.addEventListener('click', eventListener);
@@ -66,19 +73,52 @@
             });
         });
 
-        describe("dispatchEvent(eventType[, ...args])", function () {
+        describe("clearEventListeners([eventType])", () => {
 
-            it("should throw error if the eventType does not exist", function () {
+            it("should throw error if eventType does not exist", () => {
                 const eventTarget = new StyledElements.ObjectWithEvents(['click']);
 
-                expect(function () {
+                expect(() => {
+                    eventTarget.clearEventListeners('focus');
+                }).toThrow(jasmine.any(Error));
+            });
+
+            it("should clear all the listeners for a given event", () => {
+                const eventTarget = new StyledElements.ObjectWithEvents(['click']);
+                eventTarget.addEventListener("click", () => {});
+                eventTarget.addEventListener("click", () => {});
+
+                eventTarget.clearEventListeners("click");
+
+                expect(eventTarget.events.click.handlers).toEqual([]);
+            });
+
+            it("should clear all the listeners of all the events if not providing an event name", () => {
+                const eventTarget = new StyledElements.ObjectWithEvents(["click", "focus"]);
+                eventTarget.addEventListener("click", () => {});
+                eventTarget.addEventListener("focus", () => {});
+
+                eventTarget.clearEventListeners();
+
+                expect(eventTarget.events.click.handlers).toEqual([]);
+                expect(eventTarget.events.focus.handlers).toEqual([]);
+            });
+
+        });
+
+        describe("dispatchEvent(eventType[, ...args])", () => {
+
+            it("should throw error if the eventType does not exist", () => {
+                const eventTarget = new StyledElements.ObjectWithEvents(['click']);
+
+                expect(() => {
                     eventTarget.dispatchEvent('focus');
                 }).toThrow(jasmine.any(Error));
             });
 
-            it("should allow adding an event listeners while the event is dispatching", function () {
+            it("should allow adding an event listeners while the event is dispatching", () => {
                 const eventTarget = new StyledElements.ObjectWithEvents(['click']);
-                const eventListener1 = function (element) {
+                const eventListener1 = (element) => {
                     eventTarget.addEventListener('click', eventListener2);
                 };
                 const eventListener2 = jasmine.createSpy('eventListener2');
@@ -89,9 +129,9 @@
                 expect(eventListener2).toHaveBeenCalledWith(eventTarget);
             });
 
-            it("should allow removing event listeners while the event is dispatching", function () {
+            it("should allow removing event listeners while the event is dispatching", () => {
                 const eventTarget = new StyledElements.ObjectWithEvents(['click']);
-                const eventListener1 = function (element) {
+                const eventListener1 = (element) => {
                     eventTarget.removeEventListener('click', eventListener2);
                 };
                 const eventListener2 = jasmine.createSpy('eventListener2');
@@ -107,7 +147,7 @@
                 expect(eventListener3).toHaveBeenCalledWith(eventTarget);
             });
 
-            it("should call all eventListener listeners despite whether one of them thrown an error", function () {
+            it("should call all eventListener listeners despite whether one of them thrown an error", () => {
                 spyOn(window.console, "error");
                 const eventTarget = new StyledElements.ObjectWithEvents(['click']);
                 const eventListener1 = jasmine.createSpy('eventListener1').and.throwError();
@@ -124,28 +164,60 @@
             });
         });
 
-        describe("removeEventListener(eventType, eventListener)", function () {
+        describe("off(eventType, eventListener", () => {
 
-            it("should throw error if the eventType does not exist", function () {
+            it("should be a proxy to removeEventListener", () => {
                 const eventTarget = new StyledElements.ObjectWithEvents(['click']);
-                const eventListener = function (element) {};
+                const eventListener = (element) => {};
+                const response = Object.freeze({});
+                spyOn(eventTarget, "removeEventListener").and.returnValue(response);
 
-                expect(function () {
+                const r = eventTarget.off("click", eventListener);
+
+                expect(r).toBe(response);
+                expect(eventTarget.removeEventListener).toHaveBeenCalledWith("click", eventListener);
+            });
+
+        });
+
+        describe("on(eventType, eventListener", () => {
+
+            it("should be a proxy to addEventListener", () => {
+                const eventTarget = new StyledElements.ObjectWithEvents(['click']);
+                const eventListener = (element) => {};
+                const response = Object.freeze({});
+                spyOn(eventTarget, "addEventListener").and.returnValue(response);
+
+                const r = eventTarget.on("click", eventListener);
+
+                expect(r).toBe(response);
+                expect(eventTarget.addEventListener).toHaveBeenCalledWith("click", eventListener);
+            });
+
+        });
+
+        describe("removeEventListener(eventType, eventListener)", () => {
+
+            it("should throw error if the eventType does not exist", () => {
+                const eventTarget = new StyledElements.ObjectWithEvents(['click']);
+                const eventListener = (element) => {};
+
+                expect(() => {
                     eventTarget.removeEventListener('focus', eventListener);
                 }).toThrow(jasmine.any(Error));
             });
 
-            it("should throw error if the eventListener is not a function", function () {
+            it("should throw error if the eventListener is not a function", () => {
                 const eventTarget = new StyledElements.ObjectWithEvents(['click']);
 
-                expect(function () {
+                expect(() => {
                     eventTarget.removeEventListener('click', null);
                 }).toThrow(jasmine.any(TypeError));
             });
 
-            it("should remove all references of the eventListener", function () {
+            it("should remove all references of the eventListener", () => {
                 const eventTarget = new StyledElements.ObjectWithEvents(['click']);
-                const eventListener = function (element) {};
+                const eventListener = (element) => {};
 
                 eventTarget.addEventListener('click', eventListener);
                 eventTarget.addEventListener('click', eventListener);

--- a/src/wirecloud/commons/static/js/StyledElements/Event.js
+++ b/src/wirecloud/commons/static/js/StyledElements/Event.js
@@ -80,6 +80,7 @@
 
         dispatch() {
             const priv = privates.get(this);
+            const args = [this.context, ...arguments];
             priv.dispatching = true;
 
             for (let i = 0; i < this.handlers.length; i++) {
@@ -87,7 +88,7 @@
                     continue;
                 }
                 try {
-                    this.handlers[i].apply(this.context, arguments);
+                    this.handlers[i].apply(this.context, args);
                 } catch (e) {
                     if (window.console != null && typeof window.console.error === 'function') {
                         window.console.error(e);

--- a/src/wirecloud/commons/static/js/StyledElements/ObjectWithEvents.js
+++ b/src/wirecloud/commons/static/js/StyledElements/ObjectWithEvents.js
@@ -97,11 +97,12 @@
         }
 
         /**
-         * Removes all event handlers for a given event.
+         * Removes all event handlers for a given event. If no event name is
+         * provided, all events will be cleared.
          *
          * @since 0.5
          *
-         * @param {String} name
+         * @param {String} [name]
          *      event name
          *
          * @returns {StyledElements.ObjectWithEvents}

--- a/src/wirecloud/commons/static/js/StyledElements/ObjectWithEvents.js
+++ b/src/wirecloud/commons/static/js/StyledElements/ObjectWithEvents.js
@@ -1,6 +1,6 @@
 /*
  *     Copyright (c) 2008-2016 CoNWeT Lab., Universidad Politécnica de Madrid
- *     Copyright (c) 2020 Future Internet Consulting and Development Solutions S.L.
+ *     Copyright (c) 2020-2021 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -58,15 +58,14 @@
          * @returns {StyledElements.ObjectWithEvents}
          *      The instance on which the member is called.
          */
-        dispatchEvent(name) {
+        dispatchEvent(name, ...args) {
             if (!(name in this.events)) {
                 throw new Error(utils.interpolate("Unhandled event '%(name)s'", {
                     name: name
                 }));
             }
 
-            const handlerArgs = [this].concat(Array.prototype.slice.call(arguments, 1));
-            this.events[name].dispatch.apply(this.events[name], handlerArgs);
+            this.events[name].dispatch(...args);
 
             return this;
         }
@@ -164,46 +163,50 @@
             return this;
         }
 
+        /**
+         * Attaches an event handler for a given event. This method is an alias of
+         * {@link StyledElements.ObjectWithEvents#addEventListener}.
+         *
+         * @since 0.7
+         *
+         * @memberof StyledElements.ObjectWithEvents
+         * @name StyledElements.ObjectWithEvents#on
+         * @method
+         *
+         * @param {String} name
+         *      Event name
+         * @param {Function} handler
+         *      An event handler to execute when the event is triggered
+         *
+         * @returns {StyledElements.ObjectWithEvents}
+         *      The instance on which the member is called
+         */
+        on() {
+            return this.addEventListener(...arguments);
+        }
+
+        /**
+         * Removes an event handler from a given event. This method is an alias of
+         * {@link StyledElements.ObjectWithEvents#removeEventListener}.
+         *
+         * @since 0.7
+         *
+         * @memberof StyledElements.ObjectWithEvents
+         * @name StyledElements.ObjectWithEvents#off
+         * @method
+         *
+         * @param {String} name
+         *      Event name
+         * @param {Function} handler
+         *      A previously attached event
+         *
+         * @returns {StyledElements.ObjectWithEvents}
+         *      The instance on which the member is called
+         */
+        off() {
+            return this.removeEventListener(...arguments);
+        }
+
     }
-
-    /**
-     * Attaches an event handler for a given event. This method is an alias of
-     * {@link StyledElements.ObjectWithEvents#addEventListener}.
-     *
-     * @since 0.7
-     *
-     * @memberof StyledElements.ObjectWithEvents
-     * @name StyledElements.ObjectWithEvents#on
-     * @method
-     *
-     * @param {String} name
-     *      Event name
-     * @param {Function} handler
-     *      An event handler to execute when the event is triggered
-     *
-     * @returns {StyledElements.ObjectWithEvents}
-     *      The instance on which the member is called
-     */
-    se.ObjectWithEvents.prototype.on = se.ObjectWithEvents.prototype.addEventListener;
-
-    /**
-     * Removes an event handler from a given event. This method is an alias of
-     * {@link StyledElements.ObjectWithEvents#removeEventListener}.
-     *
-     * @since 0.7
-     *
-     * @memberof StyledElements.ObjectWithEvents
-     * @name StyledElements.ObjectWithEvents#off
-     * @method
-     *
-     * @param {String} name
-     *      Event name
-     * @param {Function} handler
-     *      A previously attached event
-     *
-     * @returns {StyledElements.ObjectWithEvents}
-     *      The instance on which the member is called
-     */
-    se.ObjectWithEvents.prototype.off = se.ObjectWithEvents.prototype.removeEventListener;
 
 })(StyledElements, StyledElements.Utils);


### PR DESCRIPTION
## Proposed changes

This PR fixes some problems using the shared StyledElements API from widgets.

## Types of changes

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/Wirecloud/wirecloud/blob/develop/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A