### PR TITLE
Popover improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
           DJANGO_VERSION: ${{ matrix.django-version }}
         run: |
           pip install "Django>=${DJANGO_VERSION},<${DJANGO_VERSION%.*}.$((${DJANGO_VERSION#*.} + 1))"
-          pip install psycopg2-binary
+          pip install "psycopg2-binary<2.9"
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
           python manage.py collectstatic -v 0 -c --noinput
@@ -131,7 +131,7 @@ jobs:
         working-directory: ./src
         run: |
           pip install "Django>=2.2,<2.3"
-          pip install psycopg2-binary
+          pip install "psycopg2-binary<2.9"
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
           cp ci_scripts/base_settings.py settings.py
@@ -185,7 +185,7 @@ jobs:
           MOZ_HEADLESS: 1
         run: |
           pip install "Django>=2.2,<2.3"
-          pip install psycopg2-binary
+          pip install "psycopg2-binary<2.9"
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
           cp ci_scripts/base_settings.py settings.py

--- a/src/js_tests/styledelements/PopoverSpec.js
+++ b/src/js_tests/styledelements/PopoverSpec.js
@@ -183,6 +183,8 @@
             it("should work when using the refContainer option", () => {
                 const ref_element = new se.Button();
                 const refContainer = {
+                    addEventListener: jasmine.createSpy("addEventListener"),
+                    removeEventListener: jasmine.createSpy("removeEventListener"),
                     contextManager: {
                         addCallback: jasmine.createSpy(),
                         removeCallback: jasmine.createSpy()
@@ -451,9 +453,11 @@
             it("should manage visible changes when using the refContainer option", () => {
                 const ref_element = new StyledElements.Button();
                 const refContainer = {
+                    addEventListener: jasmine.createSpy("addEventListener"),
+                    removeEventListener: jasmine.createSpy("removeEventListener"),
                     contextManager: {
-                        addCallback: jasmine.createSpy(),
-                        removeCallback: jasmine.createSpy()
+                        addCallback: jasmine.createSpy("addCallback"),
+                        removeCallback: jasmine.createSpy("removeCallback")
                     }
                 };
                 const popover = new StyledElements.Popover({
@@ -471,9 +475,11 @@
             it("should ignore widget changes not affecting visiblity when using the refContainer option", () => {
                 const ref_element = new StyledElements.Button();
                 const refContainer = {
+                    addEventListener: jasmine.createSpy("addEventListener"),
+                    removeEventListener: jasmine.createSpy("removeEventListener"),
                     contextManager: {
-                        addCallback: jasmine.createSpy(),
-                        removeCallback: jasmine.createSpy()
+                        addCallback: jasmine.createSpy("addCallback"),
+                        removeCallback: jasmine.createSpy("removeCallback")
                     }
                 };
                 const popover = new StyledElements.Popover({
@@ -486,6 +492,29 @@
                 });
                 const element = document.querySelector('.popover');
                 expect([...element.classList]).not.toContain("hidden");
+            });
+
+            it("should manage unload events from widgets when using the refContainer option", () => {
+                const ref_element = new StyledElements.Button();
+                const refContainer = {
+                    addEventListener: jasmine.createSpy("addEventListener"),
+                    removeEventListener: jasmine.createSpy("removeEventListener"),
+                    contextManager: {
+                        addCallback: jasmine.createSpy("addCallback"),
+                        removeCallback: jasmine.createSpy("removeCallback")
+                    }
+                };
+                const popover = new StyledElements.Popover({
+                    refContainer: refContainer
+                });
+                spyOn(popover, "hide").and.callThrough();
+                expect(popover.show(ref_element)).toBe(popover);
+
+                refContainer.addEventListener.calls.argsFor(0)[1](popover, refContainer);
+
+                expect(refContainer.removeEventListener).toHaveBeenCalled();
+                expect(refContainer.contextManager.removeCallback).toHaveBeenCalled();
+                expect(popover.hide).toHaveBeenCalled();
             });
 
         });

--- a/src/js_tests/styledelements/PopoverSpec.js
+++ b/src/js_tests/styledelements/PopoverSpec.js
@@ -23,7 +23,7 @@
 /* globals StyledElements, Wirecloud */
 
 
-(function (se) {
+(function (se, utils) {
 
     "use strict";
 
@@ -347,8 +347,38 @@
                 element.dispatchEvent(new Event("transitionend"));
             });
 
+            it("should manage fullscreen mode change events (entering fullscreen)", () => {
+                const ref_element = new StyledElements.Button();
+                const popover = new StyledElements.Popover();
+                const fullscreen_element = document.createElement("div");
+                spyOn(utils, "onFullscreenChange");
+                spyOn(utils, "getFullscreenElement");
+                expect(popover.show(ref_element)).toBe(popover);
+                // Change fullscreen element
+                utils.getFullscreenElement.and.returnValue(fullscreen_element);
+
+                utils.onFullscreenChange.calls.argsFor(0)[1]();
+
+                expect(fullscreen_element.childElementCount).toBe(1);
+            });
+
+            it("should manage fullscreen mode change events (exiting fullscreen)", () => {
+                const ref_element = new StyledElements.Button();
+                const popover = new StyledElements.Popover();
+                const fullscreen_element = document.createElement("div");
+                spyOn(utils, "onFullscreenChange");
+                spyOn(utils, "getFullscreenElement").and.returnValue(fullscreen_element);
+                expect(popover.show(ref_element)).toBe(popover);
+                // Remove fullscreen element
+                utils.getFullscreenElement.and.returnValue(null);
+
+                utils.onFullscreenChange.calls.argsFor(0)[1]();
+
+                expect(fullscreen_element.childElementCount).toBe(0);
+            });
+
         });
 
     });
 
-})(StyledElements);
+})(StyledElements, StyledElements.Utils);

--- a/src/js_tests/styledelements/PopoverSpec.js
+++ b/src/js_tests/styledelements/PopoverSpec.js
@@ -79,6 +79,40 @@
 
         });
 
+        describe("disablePointerEvents()", () => {
+
+            it("should work when popover is not visible", () => {
+                const tooltip = new StyledElements.Popover();
+                expect(tooltip.disablePointerEvents()).toBe(tooltip);
+            });
+
+            it("should work when popover is visible", () => {
+                const ref_element = new StyledElements.Button();
+                const tooltip = new StyledElements.Popover();
+                tooltip.show(ref_element);
+
+                expect(tooltip.disablePointerEvents()).toBe(tooltip);
+            });
+
+        });
+
+        describe("enablePointerEvents()", () => {
+
+            it("should work when popover is not visible", () => {
+                const tooltip = new StyledElements.Popover();
+                expect(tooltip.enablePointerEvents()).toBe(tooltip);
+            });
+
+            it("should work when popover is visible", () => {
+                const ref_element = new StyledElements.Button();
+                const tooltip = new StyledElements.Popover();
+                tooltip.show(ref_element);
+
+                expect(tooltip.enablePointerEvents()).toBe(tooltip);
+            });
+
+        });
+
         describe("hide()", () => {
 
             afterEach(() => {

--- a/src/js_tests/wirecloud/UserInterfaceManagerSpec.js
+++ b/src/js_tests/wirecloud/UserInterfaceManagerSpec.js
@@ -96,6 +96,46 @@
 
         });
 
+        describe("handleEscapeEvent", () => {
+
+            beforeEach(() => {
+                spyOn(Wirecloud.HistoryManager, "getCurrentState");
+                spyOn(Wirecloud.HistoryManager, "replaceState");
+                Wirecloud.UserInterfaceManager.init();
+                jasmine.clock().install();
+            });
+
+            afterEach(() => {
+                jasmine.clock().uninstall();
+            });
+
+            it("should allow to be called from click events", () => {
+                const dialog = new Wirecloud.ui.MessageWindowMenu();
+                dialog.show();
+                jasmine.clock().tick(1);
+                spyOn(dialog, "hide");
+                const tooltip = new StyledElements.Tooltip();
+                Wirecloud.UserInterfaceManager._registerTooltip(tooltip);
+                spyOn(tooltip, "hide");
+
+                Wirecloud.UserInterfaceManager.handleEscapeEvent(true);
+
+                expect(dialog.hide).not.toHaveBeenCalled();
+                expect(tooltip.hide).toHaveBeenCalledWith();
+            });
+
+            it("should allow to be called from click events", () => {
+                const popover = new StyledElements.Popover({sticky: true});
+                Wirecloud.UserInterfaceManager._registerPopup(popover);
+                spyOn(popover, "hide");
+
+                Wirecloud.UserInterfaceManager.handleEscapeEvent(true);
+
+                expect(popover.hide).not.toHaveBeenCalled();
+            });
+
+        });
+
         describe("onHistoryChange(state)", () => {
 
             it("should change current view", () => {

--- a/src/js_tests/wirecloud/ui/WidgetViewSpec.js
+++ b/src/js_tests/wirecloud/ui/WidgetViewSpec.js
@@ -1,5 +1,5 @@
 /*
- *     Copyright (c) 2019-2020 Future Internet Consulting and Development Solutions S.L.
+ *     Copyright (c) 2019-2021 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -94,7 +94,8 @@
                 model: {},
                 workspace: {
                     addEventListener: jasmine.createSpy("addEventListener")
-                }
+                },
+                addEventListener: jasmine.createSpy("addEventListener")
             };
             tab.dragboard = {
                 tab: tab,
@@ -640,6 +641,86 @@
                 widget.grip.dispatchEvent("click");
 
                 expect(widget.togglePermission).toHaveBeenCalledWith("move", true);
+            });
+
+            it("should manage hide events from tab", () => {
+                widget.tab.workspace.hidden = false;
+                widget.tab.hidden = true;
+                callEventListener(widget.tab, "hide");
+
+                expect(widget.model.contextManager.modify).toHaveBeenCalledWith({
+                    visible: false
+                });
+            });
+
+            it("should manage hide events from tab (workspace hidden)", () => {
+                widget.tab.workspace.hidden = true;
+                widget.tab.hidden = true;
+                callEventListener(widget.tab, "hide");
+
+                expect(widget.model.contextManager.modify).toHaveBeenCalledWith({
+                    visible: false
+                });
+            });
+
+            it("should manage hide events from workspace", () => {
+                widget.tab.workspace.hidden = true;
+                widget.tab.hidden = false;
+                callEventListener(widget.tab.workspace, "hide");
+
+                expect(widget.model.contextManager.modify).toHaveBeenCalledWith({
+                    visible: false
+                });
+            });
+
+            it("should manage hide events from workspace (tab hidden)", () => {
+                widget.tab.workspace.hidden = true;
+                widget.tab.hidden = true;
+                callEventListener(widget.tab.workspace, "hide");
+
+                expect(widget.model.contextManager.modify).toHaveBeenCalledWith({
+                    visible: false
+                });
+            });
+
+            it("should manage show events from tab", () => {
+                widget.tab.workspace.hidden = false;
+                widget.tab.hidden = false;
+                callEventListener(widget.tab, "show");
+
+                expect(widget.model.contextManager.modify).toHaveBeenCalledWith({
+                    visible: true
+                });
+            });
+
+            it("should manage show events from tab (workspace hidden)", () => {
+                widget.tab.workspace.hidden = true;
+                widget.tab.hidden = false;
+                callEventListener(widget.tab, "show");
+
+                expect(widget.model.contextManager.modify).toHaveBeenCalledWith({
+                    visible: false
+                });
+            });
+
+            it("should manage show events from workspace", () => {
+                widget.tab.workspace.hidden = false;
+                widget.tab.hidden = false;
+                callEventListener(widget.tab.workspace, "show");
+
+                expect(widget.model.contextManager.modify).toHaveBeenCalledWith({
+                    visible: true
+                });
+            });
+
+            it("should manage show events from workspace (tab hidden)", () => {
+                widget.tab.workspace.hidden = false;
+                widget.tab.hidden = true;
+                callEventListener(widget.tab.workspace, "show");
+
+                expect(widget.model.contextManager.modify).toHaveBeenCalledWith({
+                    visible: false
+                });
             });
 
         });

--- a/src/wirecloud/commons/static/js/StyledElements/Popover.js
+++ b/src/wirecloud/commons/static/js/StyledElements/Popover.js
@@ -271,6 +271,26 @@
             return this;
         }
 
+        disablePointerEvents() {
+            const priv = privates.get(this);
+
+            if (priv.element) {
+                priv.element.style.pointerEvents = "none";
+            }
+
+            return this;
+        }
+
+        enablePointerEvents() {
+            const priv = privates.get(this);
+
+            if (priv.element) {
+                priv.element.style.pointerEvents = "";
+            }
+
+            return this;
+        }
+
         toggle(refElement) {
             if (this.visible) {
                 return this.hide();

--- a/src/wirecloud/commons/static/js/StyledElements/Popover.js
+++ b/src/wirecloud/commons/static/js/StyledElements/Popover.js
@@ -153,7 +153,7 @@
         const priv = privates.get(this);
 
         if ('Wirecloud' in window) {
-            Wirecloud.UserInterfaceManager._registerPopup(this, this.options.sticky);
+            Wirecloud.UserInterfaceManager._registerPopup(this);
         }
 
         if (this.visible) {
@@ -207,12 +207,18 @@
         }
     };
 
-    /**
-     * options:
-     * - `sticky` (experimental)
-     */
+
     se.Popover = class Popover extends se.StyledElement {
 
+        /**
+         * @param {Object} [options] a dictionary with popover options
+         * @param {Wirecloud.ui.WidgetView} [options.refContainer] Widget
+         *   associated with this popover. Visibility of the popover with be
+         *   controlled also with the visibility of the widget. This is a
+         *   WireCloud related feature.
+         * @param {boolean} [options.sticky] If `true`, the popover won't be
+         *   closed when clicking on the document.
+         */
         constructor(options) {
             const defaultOptions = {
                 refContainer: null,
@@ -239,7 +245,7 @@
             };
             privates.set(this, priv);
 
-            delete options.refContainer;
+            delete this.options.refContainer;
         }
 
         get visible() {

--- a/src/wirecloud/commons/static/js/StyledElements/Popover.js
+++ b/src/wirecloud/commons/static/js/StyledElements/Popover.js
@@ -37,16 +37,24 @@
         }
     };
 
-    const track_element = function track_element(ref, popover) {
-        const priv = privates.get(popover);
-        priv.update_popover_visibility_bound = update_popover_visibility.bind(popover);
-        ref.contextManager.addCallback(priv.update_popover_visibility_bound);
+    const on_widget_unload = function on_widget_unload(popover, widget) {
+        popover.hide();
     };
 
-    const untrack_element = function untrack_element(ref, popover) {
+    const track_element = function track_element(widget, popover) {
         const priv = privates.get(popover);
-        ref.contextManager.removeCallback(priv.update_popover_visibility_bound);
+        priv.update_popover_visibility_bound = update_popover_visibility.bind(popover);
+        widget.contextManager.addCallback(priv.update_popover_visibility_bound);
+        priv.on_widget_unload = on_widget_unload.bind(null, popover);
+        widget.addEventListener("unload", priv.on_widget_unload);
+    };
+
+    const untrack_element = function untrack_element(widget, popover) {
+        const priv = privates.get(popover);
+        widget.contextManager.removeCallback(priv.update_popover_visibility_bound);
+        widget.removeEventListener("unload", priv.on_widget_unload);
         delete priv.update_popover_visibility_bound;
+        delete priv.on_widget_unload;
     };
 
     const disableCallback = function disableCallback(e) {

--- a/src/wirecloud/commons/static/js/StyledElements/Popover.js
+++ b/src/wirecloud/commons/static/js/StyledElements/Popover.js
@@ -152,6 +152,7 @@
         priv.baseelement = utils.getFullscreenElement() || document.body;
         priv.baseelement.appendChild(priv.element);
         priv.baseelement.addEventListener("click", priv.disableCallback, true);
+        utils.onFullscreenChange(document.body, priv.on_fullscreen_change);
 
         priv.refPosition = refPosition;
         searchBestPosition.call(this, priv.refPosition, this.options.placement);
@@ -164,6 +165,7 @@
     const _hide = function _hide() {
         const priv = privates.get(this);
         if (priv.element != null && !priv.element.classList.contains('in')) {
+            utils.removeFullscreenChangeCallback(document.body, priv.on_fullscreen_change);
             priv.element.remove();
             priv.element = null;
             priv.refPosition = null;
@@ -192,7 +194,12 @@
 
             const priv = {
                 element: null,
-                disableCallback: disableCallback.bind(this)
+                disableCallback: disableCallback.bind(this),
+                on_fullscreen_change: (event) => {
+                    priv.baseelement = utils.getFullscreenElement() || document.body;
+                    priv.baseelement.appendChild(priv.element);
+                    this.repaint();
+                }
             };
             privates.set(this, priv);
             Object.defineProperties(this, {

--- a/src/wirecloud/platform/static/js/WirecloudAPI/StyledElements.js
+++ b/src/wirecloud/platform/static/js/WirecloudAPI/StyledElements.js
@@ -195,6 +195,16 @@
             redirect_events(priv.popover, this);
         }
 
+        disablePointerEvents() {
+            privates.get(this).popover.disablePointerEvents();
+            return this;
+        }
+
+        enablePointerEvents() {
+            privates.get(this).popover.enablePointerEvents();
+            return this;
+        }
+
         get visible() {
             return privates.get(this).popover.visible;
         }

--- a/src/wirecloud/platform/static/js/WirecloudAPI/StyledElements.js
+++ b/src/wirecloud/platform/static/js/WirecloudAPI/StyledElements.js
@@ -131,6 +131,11 @@
             return this;
         }
 
+        repaint() {
+            privates.get(this).menu.repaint(...arguments);
+            return this;
+        }
+
         show(refPosition) {
             const menu = privates.get(this).menu;
             menu.show(wrap_ref_position(refPosition));
@@ -185,6 +190,11 @@
 
         get visible() {
             return privates.get(this).popover.visible;
+        }
+
+        repaint() {
+            privates.get(this).popover.repaint(...arguments);
+            return this;
         }
 
         show(refPosition) {
@@ -284,6 +294,11 @@
 
         get options() {
             return privates.get(this).tooltip.options;
+        }
+
+        repaint() {
+            privates.get(this).tooltip.repaint(...arguments);
+            return this;
         }
 
         show(refPosition) {

--- a/src/wirecloud/platform/static/js/wirecloud/UserInterfaceManager.js
+++ b/src/wirecloud/platform/static/js/wirecloud/UserInterfaceManager.js
@@ -1,6 +1,6 @@
 /*
  *     Copyright (c) 2014-2017 CoNWeT Lab., Universidad Politécnica de Madrid
- *     Copyright (c) 2019-2020 Future Internet Consulting and Development Solutions S.L.
+ *     Copyright (c) 2019-2021 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *

--- a/src/wirecloud/platform/static/js/wirecloud/UserInterfaceManager.js
+++ b/src/wirecloud/platform/static/js/wirecloud/UserInterfaceManager.js
@@ -345,13 +345,17 @@
         return alternatives.showAlternative(newView, options);
     };
 
-    UserInterfaceManager.handleEscapeEvent = function handleEscapeEvent() {
+    UserInterfaceManager.handleEscapeEvent = function handleEscapeEvent(click) {
         if (currentTooltip != null) {
             currentTooltip.hide();
             currentTooltip = null;
         } else if (currentPopups.length > 0) {
-            // Popup hide method will call _unregisterPopup
-            currentPopups[currentPopups.length - 1].hide();
+            const popup = currentPopups[currentPopups.length - 1];
+
+            if (!click || !(popup instanceof StyledElements.Popover) || !popup.options.sticky) {
+                // Popup hide method will call _unregisterPopup
+                popup.hide();
+            }
         }
     };
 

--- a/src/wirecloud/platform/static/js/wirecloud/Widget.js
+++ b/src/wirecloud/platform/static/js/wirecloud/Widget.js
@@ -556,6 +556,11 @@
                     description: utils.gettext("Widget's height in layout cells"),
                     value: data.height
                 },
+                visible: {
+                    label: utils.gettext("Visible"),
+                    description: utils.gettext("Specifies if the widget is being displayed, altough the user may have to do scroll to be able to see it"),
+                    value: false
+                },
                 width: {
                     label: utils.gettext("Width"),
                     description: utils.gettext("Widget's width in layout cells"),

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WidgetView.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WidgetView.js
@@ -387,7 +387,7 @@
                 }, true);
 
                 model.wrapperElement.contentDocument.defaultView.addEventListener('click', () => {
-                    Wirecloud.UserInterfaceManager.handleEscapeEvent();
+                    Wirecloud.UserInterfaceManager.handleEscapeEvent(true);
                     this.unhighlight();
                 }, true);
 

--- a/src/wirecloud/platform/static/js/wirecloud/ui/WidgetView.js
+++ b/src/wirecloud/platform/static/js/wirecloud/ui/WidgetView.js
@@ -1,6 +1,6 @@
 /*
  *     Copyright (c) 2013-2016 CoNWeT Lab., Universidad Politécnica de Madrid
- *     Copyright (c) 2019-2020 Future Internet Consulting and Development Solutions S.L.
+ *     Copyright (c) 2019-2021 Future Internet Consulting and Development Solutions S.L.
  *
  *     This file is part of Wirecloud Platform.
  *
@@ -95,6 +95,12 @@
             'width': this.shape.width,
             'heightInPixels': this.model.wrapperElement.offsetHeight,
             'widthInPixels': this.model.wrapperElement.offsetWidth
+        });
+    };
+
+    const update_widget_visibility = function update_widget_visibility() {
+        this.model.contextManager.modify({
+            visible: !this.minimized && !this.tab.hidden && !this.tab.workspace.hidden
         });
     };
 
@@ -390,6 +396,12 @@
 
             this.tab.workspace.addEventListener('editmode', update.bind(this));
             model.addEventListener('remove', on_remove.bind(this));
+
+            this.tab.workspace.addEventListener('show', update_widget_visibility.bind(this));
+            this.tab.workspace.addEventListener('hide', update_widget_visibility.bind(this));
+            this.tab.addEventListener('show', update_widget_visibility.bind(this));
+            this.tab.addEventListener('hide', update_widget_visibility.bind(this));
+
             update.call(this);
         }
 
@@ -432,8 +444,9 @@
             }
 
             this.model.contextManager.modify({
-                'height': this.shape.height,
-                'heightInPixels': this.model.wrapperElement.offsetHeight
+                height: this.shape.height,
+                heightInPixels: this.model.wrapperElement.offsetHeight,
+                visible: !priv.minimized && !this.tab.hidden && !this.tab.workspace.hidden
             });
 
             // Notify resize event


### PR DESCRIPTION
## Proposed changes

This PR makes some improvement on how Popovers are managed by WireCloud. Main improvement is management of the popover visibility now that we are allowing sticky popovers, as those popovers are not closed on click events, they were remaining in the user interface when moving between tabs, sections and so on, when closing widgets, .... This PR makes WireCloud aware of the widget visibility and hides/displays the popover when required and removes them on widget unload. This PR also fixes some problems when enabling/disabling fullscreen mode and some problems repainting them.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/Wirecloud/wirecloud/blob/develop/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A