### PR TITLE
Allow to update popover contents

### DIFF
--- a/src/js_tests/styledelements/PopoverSpec.js
+++ b/src/js_tests/styledelements/PopoverSpec.js
@@ -362,6 +362,30 @@
 
         });
 
+        describe("update(title, content)", () => {
+
+            it("should work when currently hidden", () => {
+                const tooltip = new StyledElements.Popover({placement: ['top']});
+
+                expect(tooltip.update("new title", "new content")).toBe(tooltip);
+
+                expect(tooltip.options.title).toBe("new title");
+                expect(tooltip.options.content).toBe("new content");
+            });
+
+            it("should work when visible", () => {
+                const ref_element = new StyledElements.Button();
+                const tooltip = new StyledElements.Popover({placement: ['top']});
+                tooltip.show(ref_element);
+
+                expect(tooltip.update("new title", "new content")).toBe(tooltip);
+
+                expect(tooltip.options.title).toBe("new title");
+                expect(tooltip.options.content).toBe("new content");
+            });
+
+        });
+
         describe("events", () => {
 
             it("should hide popover when clicking outside the popover", (done) => {

--- a/src/wirecloud/commons/static/js/StyledElements/Popover.js
+++ b/src/wirecloud/commons/static/js/StyledElements/Popover.js
@@ -321,6 +321,28 @@
             return _show.call(this, refElement);
         }
 
+        update(title, content) {
+            this.options.title = title;
+            this.options.content = content;
+
+            const priv = privates.get(this);
+            if (priv.element) {
+                priv.element.remove();
+
+                priv.element = builder.parse(template, {
+                    title: this.options.title,
+                    content: this.options.content
+                }).elements[0];
+                priv.element.addEventListener("transitionend", _hide.bind(this));
+                priv.element.classList.toggle("sticky", this.options.sticky);
+                priv.element.classList.add("in");
+                priv.baseelement.appendChild(priv.element);
+
+                this.repaint();
+            }
+            return this;
+        }
+
         hide() {
             if (!this.visible) {
                 return this;

--- a/src/wirecloud/platform/static/js/WirecloudAPI/StyledElements.js
+++ b/src/wirecloud/platform/static/js/WirecloudAPI/StyledElements.js
@@ -177,6 +177,7 @@
             privates.get(this).menu.destroy();
             return this;
         }
+
     }
 
     /* Popover */
@@ -237,6 +238,12 @@
                 this.show(refPosition);
             }
         }
+
+        update(title, content) {
+            privates.get(this).popover.update(title, content);
+            return this;
+        }
+
     }
 
     /* SendMenuItems */


### PR DESCRIPTION
## Proposed changes

This PR adds a new method `update(title, content)` method to the `StyledElements.Popover` class allowing to update popovers once initialized.

## Types of changes

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/Wirecloud/wirecloud/blob/develop/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A