### PR TITLE
Fix errors showing on console when Wirecloud is loaded as an iframe

### DIFF
--- a/src/wirecloud/platform/static/js/wirecloud/core.js
+++ b/src/wirecloud/platform/static/js/wirecloud/core.js
@@ -27,6 +27,8 @@
 
     "use strict";
 
+    window.parent = window; // Avoid problems with embedded Wirecloud instances
+
     const preferencesChanged = function preferencesChanged(preferences, modifiedValues) {
         /* istanbul ignore if */
         if ('language' in modifiedValues) {


### PR DESCRIPTION
## Proposed changes

If Wirecloud was loaded as an iframe, some errors would show up in the console. This simple fix solves that problem by making the window object behave as if it wasn't in an iframe.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/Wirecloud/wirecloud/blob/develop/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

_None_
