### PR TITLE
Improve MACs v2 loading

### DIFF
--- a/src/js_tests/wirecloud/WidgetMetaSpec.js
+++ b/src/js_tests/wirecloud/WidgetMetaSpec.js
@@ -68,21 +68,21 @@
                 }).toThrowError(TypeError);
             });
 
-            it("throws a TypeError exception when the entrypoint is missing for mac version 2", () => {
+            it("does not throw a TypeError exception when the entrypoint is missing for mac version 2", () => {
                 expect(() => {
                     new Wirecloud.WidgetMeta({
                         vendor: "Wirecloud",
                         name: "TestWidget",
-                        version: "1.0",
-                        type: "widget",
-                        js_files: [],
-                        macversion: 2,
                         preferences: [],
+                        properties: [],
+                        version: "1.0",
+                        macversion: 2,
+                        js_files: [],
                         contents: {
                             src: "index.html"
                         }
                     });
-                }).toThrowError(TypeError);
+                }).not.toThrow();
             });
 
             it("throws a TypeError exception when the js_files is missing for mac version 2", () => {
@@ -95,6 +95,7 @@
                         macversion: 2,
                         entrypoint: "Test",
                         preferences: [],
+                        properties: [],
                         contents: {
                             src: "index.html"
                         }

--- a/src/js_tests/wirecloud/wiring/OperatorMetaSpec.js
+++ b/src/js_tests/wirecloud/wiring/OperatorMetaSpec.js
@@ -63,7 +63,7 @@
                 }).toThrowError(TypeError);
             });
 
-            it("throws a TypeError exception when the entrypoint is missing for mac version 2", () => {
+            it("does not throw a TypeError exception when the entrypoint is missing for mac version 2", () => {
                 expect(() => {
                     new ns.OperatorMeta({
                         vendor: "Wirecloud",
@@ -75,7 +75,7 @@
                         macversion: 2,
                         js_files: ["Test"]
                     });
-                }).toThrowError(TypeError);
+                }).not.toThrow();
             });
 
             it("throws a TypeError exception when the js_files is missing for mac version 2", () => {

--- a/src/wirecloud/commons/utils/template/parsers/json.py
+++ b/src/wirecloud/commons/utils/template/parsers/json.py
@@ -217,7 +217,7 @@ class JSONTemplateParser(object):
 
         if self._info['type'] == 'widget':
             if self._info['macversion'] > 1:
-                self._check_string_fields(('entrypoint', ), required=True)
+                self._check_string_fields(('entrypoint', ), required=False)
 
             self._check_array_fields(('altcontents',))
             if self._info.get('contents', None) is None:
@@ -231,7 +231,7 @@ class JSONTemplateParser(object):
 
         elif self._info['type'] == 'operator':
             if self._info['macversion'] > 1:
-                self._check_string_fields(('entrypoint', ), required=True)
+                self._check_string_fields(('entrypoint', ), required=False)
 
         elif self._info['type'] == 'mashup':
 

--- a/src/wirecloud/commons/utils/template/parsers/rdf.py
+++ b/src/wirecloud/commons/utils/template/parsers/rdf.py
@@ -655,7 +655,7 @@ class RDFTemplateParser(object):
                 raise TemplateParseException(_('Missing required field: Javascript files'))
 
             if self._info['macversion'] > 1:
-                self._info['entrypoint'] = self._get_field(WIRE, 'entryPoint', self._rootURI, required=True)
+                self._info['entrypoint'] = self._get_field(WIRE, 'entryPoint', self._rootURI, required=False)
 
     def _parse_translation_catalogue(self):
         self._info['default_lang'] = 'en'

--- a/src/wirecloud/commons/utils/template/parsers/xml.py
+++ b/src/wirecloud/commons/utils/template/parsers/xml.py
@@ -445,12 +445,14 @@ class ApplicationMashupTemplateParser(object):
 
         if self._info["macversion"] > 1:
             js_files = self._xpath(SCRIPT_XPATH, self._doc)
-            
+
             self._info['js_files'] = []
             for script in js_files:
                 self._info['js_files'].append(str(script.get('src')))
 
-            self._info["entrypoint"] = self.get_xpath(ENTRYPOINT_XPATH, self._doc, required=True).get('name')
+            entrypoint = self.get_xpath(ENTRYPOINT_XPATH, self._doc, required=False)
+            if entrypoint is not None:
+                self._info["entrypoint"] = entrypoint.get('name')
         else:
             js_files = self._xpath(SCRIPT_XPATH, self._doc)
             if len(js_files) > 0:
@@ -467,7 +469,9 @@ class ApplicationMashupTemplateParser(object):
             self._info['js_files'].append(str(script.get('src')))
 
         if self._info["macversion"] > 1:
-            self._info["entrypoint"] = self.get_xpath(ENTRYPOINT_XPATH, self._doc, required=True).get('name')
+            entrypoint = self.get_xpath(ENTRYPOINT_XPATH, self._doc, required=False)
+            if entrypoint is not None:
+                self._info["entrypoint"] = entrypoint.get('name')
 
     def _parse_component_preferences(self):
 

--- a/src/wirecloud/commons/utils/template/writers/rdf.py
+++ b/src/wirecloud/commons/utils/template/writers/rdf.py
@@ -588,7 +588,7 @@ def build_rdf_graph(template_info):
             graph.add((js_node, WIRE['index'], rdflib.Literal(str(index))))
             graph.add((resource_uri, USDL['utilizedResource'], js_node))
 
-    if (template_info['type'] == 'operator' or template_info['type'] == 'widget') and template_info['macversion'] > 1:
+    if (template_info['type'] == 'operator' or template_info['type'] == 'widget') and template_info['macversion'] > 1 and 'entrypoint' in template_info:
         # Add entryPoint
         graph.add((resource_uri, WIRE['entryPoint'], rdflib.Literal(template_info.get('entrypoint'))))
 

--- a/src/wirecloud/commons/utils/template/writers/xml.py
+++ b/src/wirecloud/commons/utils/template/writers/xml.py
@@ -319,7 +319,7 @@ def build_xml_document(options):
         for script in options['js_files']:
             etree.SubElement(scripts, 'script', src=script)
 
-    if (options['type'] == 'operator' or options['type'] == 'widget') and options['macversion'] > 1:
+    if (options['type'] == 'operator' or options['type'] == 'widget') and options['macversion'] > 1 and 'entrypoint' in options:
         # Add entrypoint
         etree.SubElement(template, 'entrypoint', name=options['entrypoint'])
 

--- a/src/wirecloud/platform/static/js/WirecloudAPI/WirecloudAPIV2Bootstrap.js
+++ b/src/wirecloud/platform/static/js/WirecloudAPI/WirecloudAPIV2Bootstrap.js
@@ -69,4 +69,16 @@
         ComponentManagement: privates._ComponentManagementAPI
     };
 
+    Wirecloud.APIComponents = {}
+    const registerWidgetClass = function registerWidgetClass(script, widgetClass) {
+        Wirecloud.APIComponents[script.dataset.id] = widgetClass;
+    };
+
+    const registerOperatorClass = function registerOperatorClass(script, operatorClass) {
+        Wirecloud.APIComponents[script.dataset.id] = operatorClass;
+    }
+
+    Wirecloud.registerWidgetClass = registerWidgetClass;
+    Wirecloud.registerOperatorClass = registerOperatorClass;
+
 })(window.Wirecloud);

--- a/src/wirecloud/platform/static/js/wirecloud/Widget.js
+++ b/src/wirecloud/platform/static/js/wirecloud/Widget.js
@@ -208,6 +208,7 @@
             const script = document.createElement('script');
             script.setAttribute('type', 'text/javascript');
             script.setAttribute('src', js_file);
+            script.dataset.id = this.meta.uri;
             script.async = false;
             document.body.appendChild(script);
             this.loaded_scripts.push(script);
@@ -312,7 +313,11 @@
             // If this is a v2 or later widget, we need to instantiate it's entrypoint class
             _unloadScripts.call(this);
             _loadScripts.call(this).then(() => {
-                const entrypoint = window[this.meta.entrypoint];
+                let entrypoint = Wirecloud.APIComponents[this.meta.uri];
+                if (!entrypoint) {
+                    entrypoint = window[this.meta.entrypoint];
+                }
+
                 if (entrypoint === undefined) {
                     this.logManager.log("Widget entrypoint class not found!", {console: false});
                 } else {

--- a/src/wirecloud/platform/static/js/wirecloud/WidgetMeta.js
+++ b/src/wirecloud/platform/static/js/wirecloud/WidgetMeta.js
@@ -51,10 +51,6 @@
                     if (!this.js_files) {
                         throw new TypeError("missing js_files attribute in widget description");
                     }
-
-                    if (!this.entrypoint) {
-                        throw new TypeError("missing entrypoint attribute in widget description");
-                    }
                 }
             }
             if (this.codeurl.indexOf('?') === -1) {

--- a/src/wirecloud/platform/static/js/wirecloud/wiring/Operator.js
+++ b/src/wirecloud/platform/static/js/wirecloud/wiring/Operator.js
@@ -55,6 +55,7 @@
             const script = document.createElement('script');
             script.setAttribute('type', 'text/javascript');
             script.setAttribute('src', js_file);
+            script.dataset.id = this.meta.uri;
             script.async = false;
             document.body.appendChild(script);
             this.loaded_scripts.push(script);
@@ -203,7 +204,11 @@
             this.wrapperElement.contentDocument.defaultView.addEventListener('unload', on_unload.bind(this), true);
         } else if (!this.meta.missing && this.meta.macversion > 1) {
             // If this is a v2 or later operator, we need to instantiate it's entrypoint class
-            const entrypoint = window[this.meta.entrypoint];
+            let entrypoint = Wirecloud.APIComponents[this.meta.uri];
+            if (!entrypoint) {
+                entrypoint = window[this.meta.entrypoint];
+            }
+
             if (entrypoint === undefined) {
                 this.logManager.log("Operator entrypoint class not found!", {console: false});
             } else {

--- a/src/wirecloud/platform/static/js/wirecloud/wiring/OperatorMeta.js
+++ b/src/wirecloud/platform/static/js/wirecloud/wiring/OperatorMeta.js
@@ -58,10 +58,6 @@
                 if (!this.js_files) {
                     throw new TypeError("missing js_files attribute in operator description");
                 }
-
-                if (!this.entrypoint) {
-                    throw new TypeError("missing entrypoint attribute in operator description");
-                }
             }
 
             desc.properties.forEach((property_info) => {


### PR DESCRIPTION
## Proposed changes

Improves the way of loading v2 widgets and operators.
Changes:
- Now `entrypoint` is optional.
- There are 2 new functions available to widgets and operators: `Wirecloud.registerWidgetClass(script, class)` and `Wirecloud.registerOperatorClass(script, class)`. Both receive the current script element of the DOM, accessible by `document.currentScript`, and the class entrypoint of the widget (the one that receives the MashupPlatform).

With these changes, the window object does not have to be polluted with widgets and operators defining their class in it, which also helps to prevent conflicts between them. The other way of loading them, with the `entrypoint` configuration, still works.

Along with this PR, more will be done in the grunt-init and config-parser repositories.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/Wirecloud/wirecloud/blob/develop/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules

## Further comments

_None_
