### PR TITLE
Remove django relatives and django appconf

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,7 +6,6 @@ rdflib>=3.2.0
 requests>=2.1.0
 selenium>=3.4
 pytz
-django_relatives>1.0.0,<2.0.0
 user-agents
 regex
 markdown

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,5 @@
 Django>=2.0,<2.3
 lxml>=2.3
-django-appconf>=1.0.1,<2.0
 django_compressor>=2.0,<2.3
 rdflib>=3.2.0
 requests>=2.1.0

--- a/src/wirecloud/platform/admin.py
+++ b/src/wirecloud/platform/admin.py
@@ -20,7 +20,6 @@
 
 from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
-from relatives.utils import object_edit_link
 
 from wirecloud.platform import models
 
@@ -68,9 +67,8 @@ class TabPreferenceInline(admin.TabularInline):
 class TabInline(admin.TabularInline):
 
     model = models.Tab
-    edit_link = object_edit_link(_("Edit"))
-    fields = ('name', 'position', edit_link)
-    readonly_fields = (edit_link,)
+    show_change_link = True
+    fields = ('name', 'position')
     ordering = ('position',)
     extra = 1
 


### PR DESCRIPTION
## Proposed changes

This PR removes `django-relatives` since the only function Wirecloud uses from it can be replaced with a builtin django option. It also removes `django-appconf` from requirements.txt since it wasn't used (a dependency uses it but not the main Wirecloud package)

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/Wirecloud/wirecloud/blob/develop/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...
