### PR TITLE
Fix preference remaining in an invalid state

### DIFF
--- a/src/wirecloud/platform/static/js/wirecloud/Preferences.js
+++ b/src/wirecloud/platform/static/js/wirecloud/Preferences.js
@@ -92,8 +92,11 @@
                 const changes = utils.clone(newValues[name]);
                 let changed = false;
 
+                let isInheriting = preference.inherit;
+
                 if ('inherit' in changes) {
                     if (preference.inherit !== changes.inherit) {
+                        isInheriting = changes.inherit;
                         changed = persist = true;
                     } else {
                         delete changes.inherit;
@@ -101,7 +104,7 @@
                 }
 
                 if ('value' in changes) {
-                    if (preference.value !== changes.value) {
+                    if (preference.value !== changes.value || (!isInheriting && changed)) {
                         changed = persist = true;
                         changes.value = Wirecloud.ui.InputInterfaceFactory.stringify(preference.meta.options.type, changes.value);
                     } else {


### PR DESCRIPTION
## Proposed changes

This fixes an error where the preferences would remain in an invalid state if a tab inheritance is deselected the first time without then changing the default value.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/Wirecloud/wirecloud/blob/develop/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules
